### PR TITLE
Added s3:GetAccelerateConfiguration action to the backup user

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -129,7 +129,8 @@ data "aws_iam_policy_document" "s3_crud" {
     effect = "Allow"
     actions = [
       "s3:ListBucket",
-      "s3:*Object"
+      "s3:*Object",
+      "s3:GetAccelerateConfiguration"
     ]
     resources = [
       # the exact ARN is needed for the list bucket action, star for put,get,delete


### PR DESCRIPTION
## Description

Added a new action `s3:GetAccelerateConfiguration` to the permissions of the backup user. This action allows the user to retrieve the configuration of Amazon S3 Transfer Acceleration for a bucket.

## Related Issues

TES-246

## Changes

- Added the `s3:GetAccelerateConfiguration` action to the permissions of the backup user.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes thoroughly.

