### PR TITLE
add ability to create a tls listener on the load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,9 @@ module "load_balancer" {
   lb_health_check_path          = var.lb_health_check_path
   lb_health_check_interval      = var.lb_health_check_interval
   lb_enable_deletion_protection = var.prevent_resource_deletion
+  tls_enabled                   = var.tls_enabled
+  tls_certificate_arn           = var.tls_certificate_arn
+  tls_policy                    = var.tls_policy
 }
 
 module "user_data" {

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -46,3 +46,21 @@ variable "lb_enable_deletion_protection" {
   type        = bool
   default     = true
 }
+
+variable "tls_enabled" {
+  description = "If enabled, a certificate must be imported in ACM and its ARN to set in tls_certificate_arn. Certificates with RSA keys larger than 2048-bit or EC keys cannot be used."
+  type        = bool
+  default     = false
+}
+
+variable "tls_policy" {
+  description = "TLS security policy on the listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "tls_certificate_arn" {
+  description = "ARN of the certificate, imported in ACM, which will be used for the TLS listener on the load balancer."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,21 @@ variable "zone_dns_name" {
   type        = string
   default     = "graphdb.cluster"
 }
+
+variable "tls_enabled" {
+  description = "If enabled, a certificate must be imported in ACM and its ARN set in the tls_certificate_arn variable. Certificates with RSA keys larger than 2048-bit or EC keys cannot be used."
+  type        = bool
+  default     = false
+}
+
+variable "tls_policy" {
+  description = "TLS security policy on the listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "tls_certificate_arn" {
+  description = "ARN of the certificate, imported in ACM, which will be used for the TLS listener on the load balancer."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description

Added the `tls_enabled` flag which controls the type of lister to be created. If set to `true`, the `tls_certificate_arn` variable must also be set in order to be connected to the listener.

## Related Issues

GDB-8733

## Changes

Added options that control the type of listener to be created for the GraphDB load balancer.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
