### PR TITLE
Extend s3 policy document

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -130,7 +130,9 @@ data "aws_iam_policy_document" "s3_crud" {
     actions = [
       "s3:ListBucket",
       "s3:*Object",
-      "s3:GetAccelerateConfiguration"
+      "s3:GetAccelerateConfiguration",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload"
     ]
     resources = [
       # the exact ARN is needed for the list bucket action, star for put,get,delete


### PR DESCRIPTION
## Description

Added additional actions to the S3 policy document to handle the cases where GraphDB needs to abort and clean up multipart uploads.

## Related Issues

GDB-8401
