### PR TITLE
Reduced the jvm_max_memory

### DIFF
--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -3,8 +3,8 @@ data "aws_ec2_instance_type" "graphdb" {
 }
 
 locals {
-  # MiB to GiB - 4
-  jvm_max_memory = ceil(data.aws_ec2_instance_type.graphdb.memory_size * 0.0009765625 - 4)
+  # MiB to GiB - 10
+  jvm_max_memory = ceil(data.aws_ec2_instance_type.graphdb.memory_size * 0.0009765625 - 10)
 
   graphdb_user_data = templatefile(
     var.user_supplied_userdata_path != null ? var.user_supplied_userdata_path : "${path.module}/templates/start_graphdb.sh.tpl",


### PR DESCRIPTION
## Description

Reducing the jvm_max_memory, because as it is set leaves only 4gb for the off-heap, classes loaded, the OS itself or stacks of threads or the memory used for the JIT for instance. 

## Related Issues

N/A

## Changes

The heap memory will now take total VM memory minus 10GB.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
