### PR TITLE
Add SSM parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 data "aws_region" "current" {}
 
+data "aws_caller_identity" "current" {}
+
 module "vpc" {
   source = "./modules/vpc"
 
@@ -43,11 +45,13 @@ module "backup" {
 module "config" {
   source = "./modules/config"
 
-  resource_name_prefix   = var.resource_name_prefix
-  graphdb_license_path   = var.graphdb_license_path
-  graphdb_lb_dns_name    = module.load_balancer.lb_dns_name
-  graphdb_admin_password = var.graphdb_admin_password
-  graphdb_cluster_token  = var.graphdb_cluster_token
+  resource_name_prefix    = var.resource_name_prefix
+  graphdb_license_path    = var.graphdb_license_path
+  graphdb_lb_dns_name     = module.load_balancer.lb_dns_name
+  graphdb_admin_password  = var.graphdb_admin_password
+  graphdb_cluster_token   = var.graphdb_cluster_token
+  graphdb_properties_path = var.graphdb_properties_path
+  graphdb_java_options    = var.graphdb_java_options
 }
 
 module "load_balancer" {
@@ -118,10 +122,13 @@ module "vm" {
   graphdb_subnets           = module.vpc[0].private_subnet_ids
   graphdb_target_group_arns = local.graphdb_target_group_arns
   vpc_id                    = module.vpc[0].vpc_id
+  aws_region                = data.aws_region.current.name
+  aws_subscription_id       = data.aws_caller_identity.current.account_id
 }
 
 module "monitoring" {
-  source                            = "./modules/monitoring"
+  source = "./modules/monitoring"
+
   aws_region                        = var.monitoring_aws_region
   resource_name_prefix              = var.resource_name_prefix
   actions_enabled                   = var.monitoring_actions_enabled

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -27,16 +27,16 @@ resource "aws_ssm_parameter" "graphdb_lb_dns_name" {
   value       = var.graphdb_lb_dns_name
 }
 
-resource "aws_ssm_parameter" "graphdb_config" {
-  name        = "/${var.resource_name_prefix}/graphdb/graphdb_config"
-  description = "Initial configuration for graphdb."
+resource "aws_ssm_parameter" "graphdb_properties" {
+  name        = "/${var.resource_name_prefix}/graphdb/graphdb_properties"
+  description = "Contents of graphdb.properties file."
   type        = "SecureString"
   value       = filebase64(var.graphdb_config)
 }
 
-resource "aws_ssm_parameter" "GDB_JAVA_OPTS" {
-  name        = "/${var.resource_name_prefix}/graphdb/GDB_JAVA_OPTS"
+resource "aws_ssm_parameter" "gdb_java_opts" {
+  name        = "/${var.resource_name_prefix}/graphdb/gdb_java_opts"
   description = "Additional configurations for GraphDB."
   type        = "String"
-  value       = var.GDB_JAVA_OPTS
+  value       = var.gdb_java_opts
 }

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -26,3 +26,17 @@ resource "aws_ssm_parameter" "graphdb_lb_dns_name" {
   type        = "String"
   value       = var.graphdb_lb_dns_name
 }
+
+resource "aws_ssm_parameter" "graphdb_config" {
+  name        = "/${var.resource_name_prefix}/graphdb/graphdb_config"
+  description = "Initial configuration for graphdb."
+  type        = "SecureString" 
+  value       = filebase64(var.graphdb_config)
+}
+
+resource "aws_ssm_parameter" "GDB_JAVA_OPTS" {
+  name        = "/${var.resource_name_prefix}/graphdb/GDB_JAVA_OPTS"
+  description = "Additional configurations for GraphDB."
+  type        = "String" 
+  value       = var.GDB_JAVA_OPTS
+}

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -30,13 +30,13 @@ resource "aws_ssm_parameter" "graphdb_lb_dns_name" {
 resource "aws_ssm_parameter" "graphdb_config" {
   name        = "/${var.resource_name_prefix}/graphdb/graphdb_config"
   description = "Initial configuration for graphdb."
-  type        = "SecureString" 
+  type        = "SecureString"
   value       = filebase64(var.graphdb_config)
 }
 
 resource "aws_ssm_parameter" "GDB_JAVA_OPTS" {
   name        = "/${var.resource_name_prefix}/graphdb/GDB_JAVA_OPTS"
   description = "Additional configurations for GraphDB."
-  type        = "String" 
+  type        = "String"
   value       = var.GDB_JAVA_OPTS
 }

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -31,7 +31,7 @@ resource "aws_ssm_parameter" "graphdb_properties" {
   name        = "/${var.resource_name_prefix}/graphdb/graphdb_properties"
   description = "Contents of graphdb.properties file."
   type        = "SecureString"
-  value       = filebase64(var.graphdb_config)
+  value       = filebase64(var.graphdb_properties)
 }
 
 resource "aws_ssm_parameter" "gdb_java_opts" {

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -28,15 +28,19 @@ resource "aws_ssm_parameter" "graphdb_lb_dns_name" {
 }
 
 resource "aws_ssm_parameter" "graphdb_properties" {
+  count = var.graphdb_properties_path != null ? 1 : 0
+
   name        = "/${var.resource_name_prefix}/graphdb/graphdb_properties"
-  description = "Contents of graphdb.properties file."
+  description = "Additional properties to append to graphdb.properties file."
   type        = "SecureString"
-  value       = filebase64(var.graphdb_properties)
+  value       = filebase64(var.graphdb_properties_path)
 }
 
-resource "aws_ssm_parameter" "gdb_java_opts" {
-  name        = "/${var.resource_name_prefix}/graphdb/gdb_java_opts"
-  description = "Additional configurations for GraphDB."
+resource "aws_ssm_parameter" "graphdb_java_options" {
+  count = var.graphdb_java_options != null ? 1 : 0
+
+  name        = "/${var.resource_name_prefix}/graphdb/graphdb_java_options"
+  description = "GraphDB options to pass to GraphDB with GRAPHDB_JAVA_OPTS environment variable."
   type        = "String"
-  value       = var.gdb_java_opts
+  value       = var.graphdb_java_options
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -44,5 +44,5 @@ variable "graphdb_config" {
 variable "GDB_JAVA_OPTS" {
   description = "GDB_JAVA_OPTS Options to add for GraphDB configuration"
   type        = string
-  default     = "test"  #Need to find what to put in default since it is required to have something
+  default     = "test" #Need to find what to put in default since it is required to have something
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -35,14 +35,13 @@ variable "graphdb_lb_dns_name" {
   default     = ""
 }
 
-variable "graphdb_config" {
+variable "graphdb_properties" {
   description = "Path to the initial config to add for GraphDB."
   type        = string
-  default     = "/home/kristian/Ontotext/terraform-aws-graphdb/modules/config/example_config" #to delete and 
+  default     = null
 }
 
-variable "GDB_JAVA_OPTS" {
-  description = "GDB_JAVA_OPTS Options to add for GraphDB configuration"
+variable "gdb_java_opts" {
+  description = "Additional configurations to add to the GDB_JAVA_OPTS environment variable"
   type        = string
-  default     = "test" #Need to find what to put in default since it is required to have something
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -35,14 +35,12 @@ variable "graphdb_lb_dns_name" {
   default     = ""
 }
 
-variable "graphdb_properties" {
-  description = "Path to the initial config to add for GraphDB."
+variable "graphdb_properties_path" {
+  description = "Path to a local file with with properties which will be appended to graphdb.properties"
   type        = string
-  default     = "/home/kristian/Ontotext/properties-test"
 }
 
-variable "gdb_java_opts" {
+variable "graphdb_java_options" {
   description = "Additional configurations to add to the GDB_JAVA_OPTS environment variable"
   type        = string
-  default = "test101"
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -38,10 +38,11 @@ variable "graphdb_lb_dns_name" {
 variable "graphdb_properties" {
   description = "Path to the initial config to add for GraphDB."
   type        = string
-  default     = null
+  default     = "/home/kristian/Ontotext/properties-test"
 }
 
 variable "gdb_java_opts" {
   description = "Additional configurations to add to the GDB_JAVA_OPTS environment variable"
   type        = string
+  default = "test101"
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -34,3 +34,15 @@ variable "graphdb_lb_dns_name" {
   type        = string
   default     = ""
 }
+
+variable "graphdb_config" {
+  description = "Path to the initial config to add for GraphDB."
+  type        = string
+  default     = "/home/kristian/Ontotext/terraform-aws-graphdb/modules/config/example_config" #to delete and 
+}
+
+variable "GDB_JAVA_OPTS" {
+  description = "GDB_JAVA_OPTS Options to add for GraphDB configuration"
+  type        = string
+  default     = "test"  #Need to find what to put in default since it is required to have something
+}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_log_group" "graphdb_log_group" {
 # SSM Parameter which hosts the config for the cloudwatch agent
 
 resource "aws_ssm_parameter" "graphdb_cloudwatch_agent_config" {
-  name        = "/CWAgent/Config"
+  name        = "/${var.resource_name_prefix}/graphdb/CWAgent/Config"
   description = "Cloudwatch Agent Configuration"
   type        = var.parameter_store_ssm_parameter_type
   tier        = var.parameter_store_ssm_parameter_tier

--- a/modules/user_data/templates/06_cloudwatch_setup.sh.tpl
+++ b/modules/user_data/templates/06_cloudwatch_setup.sh.tpl
@@ -12,17 +12,26 @@ echo "#################################"
 echo "#    Cloudwatch Provisioning    #"
 echo "#################################"
 
-# Parse the CW Agent Config from SSM Parameter store and put it in file
-CWAGENT_CONFIG=$(aws ssm get-parameter --name "/CWAgent/Config" --query "Parameter.Value" --output text)
-echo "$CWAGENT_CONFIG" > /etc/graphdb/cloudwatch-agent-config.json
+parameters=$(aws ssm describe-parameters --cli-connect-timeout 300 --region ${region} --query "Parameters[?starts_with(Name, '/${name}/graphdb/')].Name" --output text)
+
+# Appends configuration overrides to graphdb.properties
+if [[ $parameters == *"/${name}/graphdb/CWAgent/Config"* ]]; then
+  # Parse the CW Agent Config from SSM Parameter store and put it in file
+  CWAGENT_CONFIG=$(aws ssm get-parameter --name "/${name}/graphdb/CWAgent/Config" --query "Parameter.Value" --output text)
+  echo "$CWAGENT_CONFIG" > /etc/graphdb/cloudwatch-agent-config.json
 
 GRAPHDB_ADMIN_PASSWORD=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/admin_password" --with-decryption --query "Parameter.Value" --output text | base64 -d)
 
-tmp=$(mktemp)
-jq '.logs.metrics_collected.prometheus.log_group_name = "${name}-graphdb"' /etc/graphdb/cloudwatch-agent-config.json > "$tmp" && mv "$tmp" /etc/graphdb/cloudwatch-agent-config.json
-jq '.logs.metrics_collected.prometheus.emf_processor.metric_namespace = "${name}-graphdb"' /etc/graphdb/cloudwatch-agent-config.json > "$tmp" && mv "$tmp" /etc/graphdb/cloudwatch-agent-config.json
-cat /etc/prometheus/prometheus.yaml | yq '.scrape_configs[].static_configs[].targets = ["localhost:7201"]' > "$tmp" && mv "$tmp" /etc/prometheus/prometheus.yaml
-cat /etc/prometheus/prometheus.yaml | yq '.scrape_configs[].basic_auth.username = "admin"' | yq ".scrape_configs[].basic_auth.password = \"$${GRAPHDB_ADMIN_PASSWORD}\"" > "$tmp" && mv "$tmp" /etc/prometheus/prometheus.yaml
+  tmp=$(mktemp)
+  jq '.logs.metrics_collected.prometheus.log_group_name = "${name}-graphdb"' /etc/graphdb/cloudwatch-agent-config.json > "$tmp" && mv "$tmp" /etc/graphdb/cloudwatch-agent-config.json
+  jq '.logs.metrics_collected.prometheus.emf_processor.metric_namespace = "${name}-graphdb"' /etc/graphdb/cloudwatch-agent-config.json > "$tmp" && mv "$tmp" /etc/graphdb/cloudwatch-agent-config.json
+  cat /etc/prometheus/prometheus.yaml | yq '.scrape_configs[].static_configs[].targets = ["localhost:7201"]' > "$tmp" && mv "$tmp" /etc/prometheus/prometheus.yaml
+  cat /etc/prometheus/prometheus.yaml | yq '.scrape_configs[].basic_auth.username = "admin"' | yq ".scrape_configs[].basic_auth.password = \"$${GRAPHDB_ADMIN_PASSWORD}\"" > "$tmp" && mv "$tmp" /etc/prometheus/prometheus.yaml
 
-amazon-cloudwatch-agent-ctl -a start
-amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/etc/graphdb/cloudwatch-agent-config.json
+  amazon-cloudwatch-agent-ctl -a start
+  amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/etc/graphdb/cloudwatch-agent-config.json
+
+else
+  echo "/${name}/graphdb/CWAgent/Config was not found! Check the deployment..."
+fi
+

--- a/modules/vm/iam.tf
+++ b/modules/vm/iam.tf
@@ -15,6 +15,24 @@ resource "aws_iam_role_policy_attachment" "systems-manager-policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "aws_iam_role_policy" "instance_ssm" {
+  name   = "${var.resource_name_prefix}-graphdb-ssm-describe"
+  role   = var.iam_role_id
+  policy = data.aws_iam_policy_document.instance_ssm.json
+}
+
+data "aws_iam_policy_document" "instance_ssm" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeParameters"
+    ]
+
+    resources = ["arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:*"]
+  }
+}
+
 data "aws_iam_policy_document" "instance_volume" {
   statement {
     effect = "Allow"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -7,7 +7,7 @@ data "aws_ec2_instance_type" "graphdb" {
 data "aws_ami" "graphdb" {
   count = var.ami_id != null ? 0 : 1
 
-  owners      = ["770034820396"] # Ontotext
+  owners      = ["408414015572"] # Ontotext
   most_recent = true
 
   filter {

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -7,7 +7,7 @@ data "aws_ec2_instance_type" "graphdb" {
 data "aws_ami" "graphdb" {
   count = var.ami_id != null ? 0 : 1
 
-  owners      = ["408414015572"] # Ontotext
+  owners      = ["770034820396"] # Ontotext
   most_recent = true
 
   filter {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -60,6 +60,16 @@ variable "instance_type" {
   type        = string
 }
 
+variable "aws_region" {
+  description = "AWS region where GraphDB is being deployed"
+  type        = string
+}
+
+variable "aws_subscription_id" {
+  description = "AWS subscription ID of the account GraphDB is being deployed in"
+  type        = string
+}
+
 # OPTIONAL parameters
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -290,7 +290,7 @@ variable "monitoring_sns_topic_endpoint" {
 }
 
 variable "monitoring_sns_protocol" {
-  description = "Define an SNS protocol that you will use to receive alers. Possible options are: Email, Email-JSON, HTTP, HTTPS."
+  description = "Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS."
   type        = string
   default     = "email"
 }
@@ -311,3 +311,16 @@ variable "monitoring_aws_region" {
   type        = string
 }
 
+# GraphDB overrides
+
+variable "graphdb_properties_path" {
+  description = "Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_java_options" {
+  description = "GraphDB options to pass to GraphDB with GRAPHDB_JAVA_OPTS environment variable."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description
Added two SSM Parameters to the parameter store. Changed the user-data script to use them
Added check if the /CWAgent/Config exists in ssm before applying it.
Made the cluster setup script exit if the cluster creation fails for unknown reason.
Added ssm:DescribeParameters permissions to the iam role
Moved graphdb_properties_path and graphdb_java_options to root level
Fixed type-o in monitoring_sns_protocol description



## Related Issues
GDB-9774

## Screenshots (if applicable)
![Screenshot from 2023-11-09 17-11-08](https://github.com/Ontotext-AD/terraform-aws-graphdb/assets/148194420/5efe9c8d-65cc-453e-bc28-a2df8cd0fe58)

## Checklist

- [ ] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [ ] All new and existing tests passed locally.
