### PR TITLE
GDB-10081-Improvements-on-SNS-Topic-and-variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ module "monitoring" {
   aws_region                        = var.aws_region
   route53_availability_check_region = var.monitoring_route53_health_check_aws_region
   actions_enabled                   = var.monitoring_actions_enabled
-  sns_topic_endpoint                = var.monitoring_sns_topic_endpoint
+  sns_topic_endpoint                = var.deploy_monitoring ? var.monitoring_sns_topic_endpoint : null
   endpoint_auto_confirms            = var.monitoring_endpoint_auto_confirms
   sns_protocol                      = var.monitoring_sns_protocol
   log_group_retention_in_days       = var.monitoring_log_group_retention_in_days

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -118,5 +118,4 @@ variable "parameter_store_ssm_parameter_type" {
 variable "route53_availability_check_region" {
   description = "Define route53 health check region"
   type        = string
-  default     = "us-east-1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -269,6 +269,7 @@ variable "monitoring_actions_enabled" {
 variable "monitoring_sns_topic_endpoint" {
   description = "Define an SNS endpoint which will be receiving the alerts via email"
   type        = string
+  default     = null
 }
 
 variable "monitoring_sns_protocol" {
@@ -286,11 +287,13 @@ variable "monitoring_endpoint_auto_confirms" {
 variable "monitoring_log_group_retention_in_days" {
   description = "Log group retention in days"
   type        = number
+  default     = 30
 }
 
 variable "monitoring_route53_health_check_aws_region" {
   description = "Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions."
   type        = string
+  default     = "us-east-1"
 }
 
 # GraphDB overrides


### PR DESCRIPTION
## Description

Added check if the deploy_monitoring is true to require monitoring_sns_topic_endpoint value. Otherwise, deploy it without requiring the monitoring_sns_topic_endpoint to be set.
Set default monitoring_log_group_retention_in_days to 30 days.
Set monitoring_route53_health_check_aws_region to us-east-1, since by default the check is deployed there because the R53 service is a global service.
## Related Issues

[GDB-10081]

## Changes

Default value set for the monitoring_route53_healthcheck_aws_region
Default value set for monitoring_log_group_retention_in_days
Added default value for monitoring_sns_topic_endpoint
Added condition to check if deploy_monitoring is true and only then require monitoring_sns_topic_endpoint to be set.

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
