### PR TITLE
GDB-10095 Introduced update_default_version to the aws_launch_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ for more details.
 - [Inputs](#inputs)
 - [Usage](#usage)
 - [Examples](#examples)
+- [Updating configurations on an active deployment](#updating-configurations-on-an-active-deployment)
 - [Local Development](#local-development)
 - [Release History](#release-history)
 - [Contributing](#contributing)
@@ -235,6 +236,22 @@ deploy_monitoring = true
 # Example ARN
 lb_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
 ```
+
+## Updating configurations on an active deployment
+
+In case your license has expired, and you need to renew it, or you need to make some changes to the `graphdb.properties`
+file, or other GraphDB related configurations, you will need to apply the changes via `terraform apply` and then either:
+
+- Terminate the instances one by one, starting with the follower nodes, and leaving the leader node to be the last
+  instance to be terminated
+- Scale down to 0 and back to number of nodes you originally had.
+
+```text
+Please be aware that the latter option will result in some downtime.
+```
+
+Both actions would trigger the user data script to be run again and update all files and properties overrides with the
+updated values.
 
 ## Local Development
 

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -66,6 +66,8 @@ resource "aws_launch_template" "graphdb" {
     http_endpoint = "enabled"
     http_tokens   = "required"
   }
+
+  update_default_version = "true"
 }
 
 resource "aws_autoscaling_group" "graphdb_auto_scalling_group" {
@@ -79,7 +81,7 @@ resource "aws_autoscaling_group" "graphdb_auto_scalling_group" {
 
   launch_template {
     id      = aws_launch_template.graphdb.id
-    version = "$Latest"
+    version = aws_launch_template.graphdb.latest_version
   }
 
   dynamic "tag" {


### PR DESCRIPTION
## Description

GDB-10095 Introduced update_default_version to the aws_launch_template
This way the latest launch template will be the default instead of the initially created one.
This is required when performing manual update of the instances as described in https://graphdb.ontotext.com/documentation/10.6/aws-deployment.html#updating-graphdb-configurations-and-versions 

## Related Issues

GDB-10095

## Changes

Added update_default_version
Changed the way the latest version of the launch_template is obtained in tf. 

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
