### PR TITLE
GDB-10121 Enabled Instance Refresh for the ASG instances

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,69 +2,63 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.15.0"
-  constraints = "~> 5.15"
+  version     = "5.49.0"
+  constraints = "~> 5.15, ~> 5.49"
   hashes = [
-    "h1:ANdCdDlCFR2frDWXfIUD2RqtBRzcaCn/3E4Jjx6qbBg=",
-    "h1:CFUr3EXmKTr3G4Nl+Yxf24NnhKQQDCyeBG+SS4YFblE=",
-    "h1:gmGBVVh5loh88jRB1eAOM5s2Bh1DSvHWp5KEA95AJkg=",
-    "zh:069d0037cd1f8791a27ec31a535ce47d02d4f220fe88f9c3caa8661c0a98892a",
-    "zh:08c18e8f5f69736e86919e6c2a68c94f39f879511d51b2a8e58ad1776ee18854",
-    "zh:41c9c95e225f72421fa4a1c3e5105f36b3b149cba1daf9bc88b0a993c1d19e07",
-    "zh:51e6cf850de8a8ae0e3b4e55b45ca2e6632a149c5851158f3c2711af51adb277",
-    "zh:5703eacc47d5a8169d1028f8cfcdf32cd12972ebea8780e870f520020280258a",
-    "zh:6a77e0406126208ae217c416e4b59940cd989df4d7d5ac23dfe8043725ff8f6a",
-    "zh:702cc6db865aeee571a639a81be3ed36326dcbda5c0a2ca91c9280772fce3e49",
-    "zh:8279822c5a267869d4459e429ad7b3b8ffaa36de2f6ca29cf7779214783ddf3a",
+    "h1:FxPN9X3/R9y952y4c4aLKB7CAHIvMTtfE9Gkmn780Sk=",
+    "zh:0979b07cdeffb868ea605e4bbc008adc7cccb5f3ba1d3a0b794ea3e8fff20932",
+    "zh:2121a0a048a1d9419df69f3561e524b7e8a6b74ba0f57bd8948799f12b6ad3a1",
+    "zh:573362042ba0bd18e98567a4f45d91b09eb0d223513518ba04f16a646a906403",
+    "zh:57be7a4d6c362be2fa586d270203f4eac1ee239816239a9503b86ebc8fa1fef0",
+    "zh:5c72ed211d9234edd70eac9d77c3cafc7bbf819d1c28332a6d77acf227c9a23c",
+    "zh:7786d1a9781f8e8c0079bf58f4ed4aeddec0caf54ad7ddcf43c47936d545a04f",
+    "zh:82133e7d39787ee91ed41988da71beecc2ecb900b5da94b3f3d77fbc4d4dc722",
+    "zh:8cdb1c154dead85be8352afd30eaf41c59249de9e7e0a8eb4ab8e625b90a4922",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:bcb74854b0742a03b46e526bc2a79f556988c7622d54ebb2ccefc72c9759e9bc",
-    "zh:c7b0f4e94a9351a004a5555e91c8fe5b7da8cd2e03411cbd59d135ea8fceedd8",
-    "zh:cec427b1ef0e0948fd16736c72de57438fafcd8eeb5aab3bb1131579d2d6d031",
-    "zh:d5e4819851e52c15283064f6fa8cb8179a69cc981bee39e9b5ce5f027da8e251",
-    "zh:dade91d49309813b7453b053429678c8e7185e5ac54b2f68edb2ffea20242149",
-    "zh:e05e1395a738317a6761b592a5643ea5e660abd32de36ece68809cfd04a6a8e3",
+    "zh:ac215fd1c3bd647ae38868940651b97a53197688daefcd70b3595c84560e5267",
+    "zh:c45db22356d20e431639061a72e07da5201f4937c1df6b9f03f32019facf3905",
+    "zh:c9ba90e62db9a4708ed1a4e094849f88ce9d44c52b49f613b30bb3f7523b8d97",
+    "zh:d2be3607be2209995c80dc1d66086d527de5d470f73509e813254067e8287106",
+    "zh:e3fa20090f3cebf3911fc7ef122bd8c0505e3330ab7d541fa945fea861205007",
+    "zh:ef1b9d5c0b6279323f2ecfc322db8083e141984cfe1bb2f33c0f4934fccb69e3",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
-  version = "2.3.3"
+  version = "2.3.4"
   hashes = [
-    "h1:GmJ8PxLjjPr+lh02Bw3u7RYqA3UtpE2hQ1T43Vt7PTQ=",
-    "h1:TNvKS2y0rYHkZgb0wabYGLKAFOnDiFbvHwoXnuOF4o8=",
-    "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
-    "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
-    "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
-    "zh:32764cfcff0d7379ca8b7dde376ac5551854d454c5881945f1952b785a312fa2",
-    "zh:55c2a4dc3ebdeaa1dec3a36db96dab253c7fa10b9fe1209862e1ee77a01e0aa1",
-    "zh:5c71f260ba5674d656d12f67cde3bb494498e6b6b6e66945ef85688f185dcf63",
+    "h1:iDq03pOzp/UsXya2h+32VOOrvGdJgI9L2/EZJoN9t4A=",
+    "zh:09f1f1e1d232da96fbf9513b0fb5263bc2fe9bee85697aa15d40bb93835efbeb",
+    "zh:381e74b90d7a038c3a8dcdcc2ce8c72d6b86da9f208a27f4b98cabe1a1032773",
+    "zh:398eb321949e28c4c5f7c52e9b1f922a10d0b2b073b7db04cb69318d24ffc5a9",
+    "zh:4a425679614a8f0fe440845828794e609b35af17db59134c4f9e56d61e979813",
+    "zh:4d955d8608ece4984c9f1dacda2a59fdb4ea6b0243872f049b388181aab8c80a",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9617280a853ec7caedb8beb7864e4b29faf9c850a453283980c28fccef2c493d",
-    "zh:ac8bda21950f8dddade3e9bc15f7bcfdee743738483be5724169943cafa611f5",
-    "zh:ba9ab567bbe63dee9197a763b3104ea9217ba27449ed54d3afa6657f412e3496",
-    "zh:effd1a7e34bae3879c02f03ed3afa979433a518e11de1f8afd35a8710231ac14",
-    "zh:f021538c86d0ac250d75e59efde6d869bbfff711eb744c8bddce79d2475bf46d",
-    "zh:f1e3984597948a2103391a26600e177b19f16a5a4c66acee27a4343fb141571f",
+    "zh:a48fbee1d58d55a1f4c92c2f38c83a37c8b2f2701ed1a3c926cefb0801fa446a",
+    "zh:b748fe6631b16a1dafd35a09377c3bffa89552af584cf95f47568b6cd31fc241",
+    "zh:d4b931f7a54603fa4692a2ec6e498b95464babd2be072bed5c7c2e140a280d99",
+    "zh:f1c9337fcfe3a7be39d179eb7986c22a979cfb2c587c05f1b3b83064f41785c5",
+    "zh:f58fc57edd1ee3250a28943cd84de3e4b744cdb52df0356a53403fc240240636",
+    "zh:f5f50de0923ff530b03e1bca0ac697534d61bb3e5fc7f60e13becb62229097a9",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.0"
-  constraints = ">= 2.0.0"
+  version     = "3.6.1"
+  constraints = "~> 3.6.0"
   hashes = [
-    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
-    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
-    "h1:S8bSIs06Vd8C/tmrTJdRyGHH1wHz+2fTfF4+jwlylrM=",
-    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
-    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
-    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
-    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
-    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "h1:0WIdXFjSCwDr4nwWPYOlaJXselSTwMaKRC4lHDJ1FUE=",
+    "zh:2a0ec154e39911f19c8214acd6241e469157489fc56b6c739f45fbed5896a176",
+    "zh:57f4e553224a5e849c99131f5e5294be3a7adcabe2d867d8a4fef8d0976e0e52",
+    "zh:58f09948c608e601bd9d0a9e47dcb78e2b2c13b4bda4d8f097d09152ea9e91c5",
+    "zh:5c2a297146ed6fb3fe934c800e78380f700f49ff24dbb5fb5463134948e3a65f",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
-    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
-    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
-    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
-    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
-    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+    "zh:7ce41e26f0603e31cdac849085fc99e5cd5b3b73414c6c6d955c0ceb249b593f",
+    "zh:8c9e8d30c4ef08ee8bcc4294dbf3c2115cd7d9049c6ba21422bd3471d92faf8a",
+    "zh:93e91be717a7ffbd6410120eb925ebb8658cc8f563de35a8b53804d33c51c8b0",
+    "zh:982542e921970d727ce10ed64795bf36c4dec77a5db0741d4665230d12250a0d",
+    "zh:b9d1873f14d6033e216510ef541c891f44d249464f13cc07d3f782d09c7d18de",
+    "zh:cfe27faa0bc9556391c8803ade135a5856c34a3fe85b9ae3bdd515013c0c87c1",
+    "zh:e4aabf3184bbb556b89e4b195eab1514c86a2914dd01c23ad9813ec17e863a8a",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | lb\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
 | lb\_enable\_access\_logs | Enable or disable access logs for the NLB | `bool` | `false` | no |
 | lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14` | no |
-| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | n/a | yes |
+| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null` | no |
+| asg\_enable\_instance\_refresh | Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch\_configuration, launch\_template, mixed\_instances\_policy | `bool` | `true` | no |
+| asg\_instance\_refresh\_checkpoint\_delay | Number of seconds to wait after a checkpoint. | `number` | `3600` | no |
+| graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false` | no |
 <!-- END_TF_DOCS -->
 
 ## Usage

--- a/main.tf
+++ b/main.tf
@@ -209,4 +209,9 @@ module "graphdb" {
 
   logging_enable_replication = var.logging_enable_bucket_replication
   backup_enable_replication  = var.backup_enable_bucket_replication
+
+  # ASG instance deployment options
+  asg_enable_instance_refresh               = var.asg_enable_instance_refresh
+  asg_instance_refresh_checkpoint_delay     = var.asg_instance_refresh_checkpoint_delay
+  graphdb_enable_userdata_scripts_on_reboot = var.graphdb_enable_userdata_scripts_on_reboot
 }

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -55,7 +55,7 @@ resource "aws_iam_role_policy_attachment" "graphdb_systems_manager_policy" {
 }
 
 resource "aws_iam_role_policy" "graphdb_instance_ssm_iam_role_policy" {
-  name   = var.resource_name_prefix
+  name   = "${var.resource_name_prefix}-describe-ssm_params"
   role   = aws_iam_role.graphdb_iam_role.id
   policy = data.aws_iam_policy_document.graphdb_instance_ssm.json
 }
@@ -68,7 +68,33 @@ data "aws_iam_policy_document" "graphdb_instance_ssm" {
       "ssm:DescribeParameters"
     ]
 
-    resources = ["arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:*"]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "graphdb_describe_resources_iam_role_policy" {
+  name   = "${var.resource_name_prefix}-describe-resources"
+  role   = aws_iam_role.graphdb_iam_role.id
+  policy = data.aws_iam_policy_document.graphdb_describe_resources.json
+}
+
+data "aws_iam_policy_document" "graphdb_describe_resources" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInstances",
+      "autoscaling:DescribeInstanceRefreshes",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeScalingActivities"
+    ]
+
+    resources = [
+      "*"
+    ]
   }
 }
 
@@ -80,8 +106,8 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
       "ec2:CreateVolume",
       "ec2:AttachVolume",
       "ec2:DescribeVolumes",
-      "ec2:DescribeInstances",
-      "ec2:MonitorInstances"
+      "ec2:MonitorInstances",
+      "ec2:CreateTags"
     ]
 
     resources = [

--- a/modules/graphdb/outputs.tf
+++ b/modules/graphdb/outputs.tf
@@ -24,7 +24,7 @@ output "s3_iam_role_name" {
 
 output "asg_name" {
   description = "Name of autoscaling group"
-  value       = aws_autoscaling_group.graphdb_auto_scalling_group.name
+  value       = aws_autoscaling_group.graphdb_auto_scaling_group.name
 }
 
 output "launch_template_id" {

--- a/modules/graphdb/templates/00_wait_node_count.sh.tpl
+++ b/modules/graphdb/templates/00_wait_node_count.sh.tpl
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This script performs the following actions:
+# * Checks if an instance refresh is in progress for the specified Auto Scaling Group (ASG).
+# * If an instance refresh is in progress, it waits for the EC2 instance status check to pass.
+# * Determines whether the current instance was created in response to the instance refresh.
+# * If the instance was created in response to the instance refresh, it waits for an available volume in the current availability zone.
+# * If no instance refresh is in progress, or if the instance was not created in response to the refresh, it proceeds with the next script.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This handles instance refreshing where new and old nodes are both present.
+# Waiting until the ASG nodes are equal to the expected node count and proceeding with the provisioning afterwards.
+IMDS_TOKEN=$(curl -Ss -H "X-aws-ec2-metadata-token-ttl-seconds: 6000" -XPUT 169.254.169.254/latest/api/token)
+AZ=$(curl -Ss -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/placement/availability-zone)
+ASG_NAME=${name}
+
+instance_refresh_status=$(aws autoscaling describe-instance-refreshes --auto-scaling-group-name "$ASG_NAME" --query 'InstanceRefreshes[?Status==`InProgress`]' --output json)
+
+if [ "$instance_refresh_status" != "[]" ]; then
+  echo "An instance refresh is currently in progress for the ASG: $ASG_NAME"
+  echo "$instance_refresh_status" | jq '.'
+
+  IMDS_TOKEN=$(curl -Ss -H "X-aws-ec2-metadata-token-ttl-seconds: 6000" -XPUT 169.254.169.254/latest/api/token)
+  INSTANCE_ID=$(curl -Ss -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/instance-id)
+
+  echo "Waiting for default EC2 status check to pass for instance $INSTANCE_ID..."
+
+  # Loop until the default status check passes
+  while true; do
+    # Get the status of the default status checks for the instance
+    instance_status=$(aws ec2 describe-instance-status --instance-ids $INSTANCE_ID --query 'InstanceStatuses[0].InstanceStatus.Status' --output text)
+    system_status=$(aws ec2 describe-instance-status --instance-ids $INSTANCE_ID --query 'InstanceStatuses[0].SystemStatus.Status' --output text)
+
+    if [[ "$instance_status" == "ok" && $system_status == "ok" ]]; then
+      echo "Default EC2 status check passed for instance $INSTANCE_ID."
+      break
+    fi
+
+    # Sleep for a while before checking again
+    sleep 5
+  done
+
+  # Determines whether or not the current instance was created in response to an instance refresh
+  matching_activities=$(aws autoscaling describe-scaling-activities --auto-scaling-group-name "$ASG_NAME" \
+    --query "Activities[?contains(Description, '$INSTANCE_ID') && contains(Cause, 'in response to an instance refresh')]" --output json)
+
+  # Find out if the current instance was created in response to an instance refresh
+  if [ "$matching_activities" != "[]" ]; then
+    echo "Current instance was created in response to instance refresh:"
+    echo "$matching_activities" | jq '.'
+
+    echo "Waiting for an available volume in $AZ"
+    while true; do
+      # Get the list of volumes in the current availability zone
+      available_volumes=$(aws ec2 describe-volumes --filters Name=availability-zone,Values=$AZ Name=status,Values=available Name=volume-type,Values=gp3 --query "Volumes[*].VolumeId" --output text)
+      # Check if any volumes are available
+      if [ -n "$available_volumes" ]; then
+        echo "Found an available volume in $AZ."
+        break
+      fi
+      sleep 5
+    done
+  else
+    echo "Current instance was not created in response to instance refresh. Proceeding with the disk provisioning script"
+  fi
+else
+  echo "No instance refresh is currently in progress for the ASG: $ASG_NAME"
+fi

--- a/modules/graphdb/templates/01_disk_management.sh.tpl
+++ b/modules/graphdb/templates/01_disk_management.sh.tpl
@@ -17,168 +17,117 @@ echo "#    Creating/Attaching managed disks     #"
 echo "###########################################"
 
 # Set common variables used throughout the script.
-IMDS_TOKEN=$(curl -Ss -H "X-aws-ec2-metadata-token-ttl-seconds: 6000" -XPUT 169.254.169.254/latest/api/token)
-INSTANCE_ID=$(curl -Ss -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/instance-id)
-AVAILABILITY_ZONE=$(curl -Ss -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/placement/availability-zone)
-VOLUME_ID=""
+IMDS_TOKEN=$(curl -s -H "X-aws-ec2-metadata-token-ttl-seconds: 6000" -X PUT 169.254.169.254/latest/api/token)
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/instance-id)
+AVAILABILITY_ZONE=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" 169.254.169.254/latest/meta-data/placement/availability-zone)
+disk_mount_point="/var/opt/graphdb"
 AVAILABLE_VOLUMES=()
 
-# Search for an available EBS volume to attach to the instance. Wait one minute for a volume to become available,
-# if no volume is found - create new one, attach, format and mount the volume.
-for i in $(seq 1 6); do
-  VOLUME_ID=$(
-    aws --cli-connect-timeout 300 ec2 describe-volumes \
-      --filters "Name=status,Values=available" "Name=availability-zone,Values=$AVAILABILITY_ZONE" "Name=tag:Name,Values=${name}-graphdb-data" \
-      --query "Volumes[*].{ID:VolumeId}" \
-      --output text | \
-      sed '/^$/d'
-  )
-
-  if [ -z "$${VOLUME_ID:-}" ]; then
-    echo 'EBS volume not yet available'
-    sleep 10
-  else
-    break
-  fi
-done
-
-# Transforms the returned result to an AVAILABLE_VOLUMES
-if [ -n "$VOLUME_ID" ]; then
-  # Loop through each element in VOLUME_ID and add it to the AVAILABLE_VOLUMES
-  while read -r element; do
-    AVAILABLE_VOLUMES+=("$element")
-  done <<< "$VOLUME_ID"
-  echo "Found volumes: $${AVAILABLE_VOLUMES[@]}"
-else
-  echo "No volumes found"
-fi
-
-# Function which creates a volume
+# Function to create a volume
 create_volume() {
   echo "Creating new volume"
-  VOLUME_ID=$(
-    aws --cli-connect-timeout 300 ec2 create-volume \
-      --availability-zone "$AVAILABILITY_ZONE" \
-      --encrypted \
-      --kms-key-id "${ebs_kms_key_arn}" \
-      --volume-type "${ebs_volume_type}" \
-      --size "${ebs_volume_size}" \
-      --iops "${ebs_volume_iops}" \
-      --throughput "${ebs_volume_throughput}" \
-      --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${name}-graphdb-data}]" | \
-      jq -r .VolumeId
-  )
-  # Transforms the returned result to an AVAILABLE_VOLUMES
-  while read -r element; do
-    AVAILABLE_VOLUMES+=("$element")
-  done <<< "$VOLUME_ID"
+  VOLUME_ID=$(aws ec2 create-volume \
+    --availability-zone "$AVAILABILITY_ZONE" \
+    --encrypted \
+    --kms-key-id "${ebs_kms_key_arn}" \
+    --volume-type "${ebs_volume_type}" \
+    --size "${ebs_volume_size}" \
+    --iops "${ebs_volume_iops}" \
+    --throughput "${ebs_volume_throughput}" \
+    --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${name}-graphdb-data}]" \
+    --query "VolumeId" --output text)
 
-  # wait for the volume to be available
-  aws --cli-connect-timeout 300 ec2 wait volume-available --volume-ids "$VOLUME_ID"
+  AVAILABLE_VOLUMES+=("$VOLUME_ID")
+
+  # Wait for the volume to be available
+  aws ec2 wait volume-available --volume-ids "$VOLUME_ID"
   echo "Successfully created volume: $VOLUME_ID"
 }
 
+# Function to attach volumes
 attach_volumes() {
-  local volume total_volumes
-  total_volumes=$${#AVAILABLE_VOLUMES[@]}
-  for ((index = 0; index < total_volumes; index++)); do
-    volume=$${AVAILABLE_VOLUMES[index]}
+  for volume in "$${AVAILABLE_VOLUMES[@]}"; do
     echo "Trying to attach volume: $volume"
-
-    if aws --cli-connect-timeout 300 ec2 attach-volume \
-      --volume-id "$volume" \
-      --instance-id "$INSTANCE_ID" \
-      --device "${device_name}"; then
+    if aws ec2 attach-volume --volume-id "$volume" --instance-id "$INSTANCE_ID" --device "${device_name}"; then
       echo "Volume $volume attached successfully"
-      break
+      return
     else
-      echo "Failed to attach volume $volume"
-      echo "Will try again with the next volume"
-
-      # Check if this is the last available volume
-      if ((index == total_volumes - 1)); then
-        echo "Attempting to create a new volume..."
-        # Resetting the AVAILABLE_VOLUMES
-        AVAILABLE_VOLUMES=()
-        create_volume
-        attach_volumes # Retry attaching volumes including the newly created one
-        break
-      fi
+      echo "Failed to attach volume $volume. Trying the next volume..."
     fi
   done
+
+  echo "No available volumes to attach. Creating a new volume..."
+  AVAILABLE_VOLUMES=()
+  create_volume
+  attach_volumes
 }
 
-if [[ -z "$${AVAILABLE_VOLUMES[@]}" ]]; then
-  create_volume
-fi
+# Check if the device is already mounted
+if mount | grep -q "on $disk_mount_point"; then
+  echo "Device is already mounted at $disk_mount_point"
+else
+  for _ in {1..6}; do
+    VOLUME_ID=$(aws ec2 describe-volumes \
+      --filters "Name=status,Values=available" "Name=availability-zone,Values=$AVAILABILITY_ZONE" "Name=tag:Name,Values=${name}-graphdb-data" \
+      --query "Volumes[*].VolumeId" --output text | tr -s '\t' '\n')
 
-attach_volumes
-
-# Handle the EBS volume used for the GraphDB data directory.
-# beware, here be dragons...
-# read these articles:
-# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
-# https://github.com/oogali/ebs-automatic-nvme-mapping/blob/master/README.md
-
-# this variable comes from terraform, and it's what we specified in the launch template as the device mapping for the ebs.
-# because this might be attached under a different name, we'll need to search for it.
-device_mapping_full="${device_name}"
-device_mapping_short="$(echo $device_mapping_full | cut -d'/' -f3)"
-
-graphdb_device=""
-
-# The device might not be available immediately, wait a while
-for i in $(seq 1 12); do
-  for volume in $(find /dev | grep -i 'nvme[0-21]n1$'); do
-    # Extract the specified device from the vendor-specific data.
-    # Read https://github.com/oogali/ebs-automatic-nvme-mapping/blob/master/README.md, for more information.
-    real_device=$(nvme id-ctrl --raw-binary $volume | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
-    if [ "$device_mapping_full" = "$real_device" ] || [ "$device_mapping_short" = "$real_device" ]; then
-      graphdb_device="$volume"
-      echo "Device found: $graphdb_device"
+    if [ -n "$VOLUME_ID" ]; then
+      AVAILABLE_VOLUMES=($VOLUME_ID)
+      echo "Found volumes: $${AVAILABLE_VOLUMES[*]}"
       break
+    else
+      echo "EBS volume not yet available. Retrying..."
+      sleep 10
     fi
   done
 
-  if [ -n "$graphdb_device" ]; then
-    break
+  if [ -z "$${AVAILABLE_VOLUMES[*]}" ]; then
+    create_volume
   fi
-  echo "Device not available, retrying ..."
-  sleep 5
-done
+  echo "No device is mounted at $disk_mount_point"
+  attach_volumes
 
-# Create a file system if there isn't any.
-if [ "$graphdb_device: data" = "$(file -s $graphdb_device)" ]; then
-  echo "Creating file system for $graphdb_device"
-  mkfs -t ext4 $graphdb_device
-fi
+  # Handle the EBS volume used for the GraphDB data directory.
+  # beware, here be dragons...
+  # read these articles:
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+  # https://github.com/oogali/ebs-automatic-nvme-mapping/blob/master/README.md
 
-disk_mount_point="/var/opt/graphdb"
+  # this variable comes from terraform, and it's what we specified in the launch template as the device mapping for the ebs.
+  # because this might be attached under a different name, we'll need to search for it.
+  device_mapping_full="${device_name}"
+  device_mapping_short=$(basename "$device_mapping_full")
+  graphdb_device=""
 
-# Check if the disk is already mounted.
-if ! mount | grep -q "$graphdb_device"; then
-  echo "The disk at $graphdb_device is not mounted."
+  for _ in {1..12}; do
+    for volume in /dev/nvme[0-21]n1; do
+      if [ -e "$volume" ]; then
+        real_device=$(nvme id-ctrl --raw-binary "$volume" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//')
+        if [[ "$device_mapping_full" == "$real_device" || "$device_mapping_short" == "$real_device" ]]; then
+          graphdb_device="$volume"
+          echo "Device found: $graphdb_device"
+          break 2
+        fi
+      fi
+    done
+    echo "Device not available, retrying ..."
+    sleep 5
+  done
 
-  # Create the mount point if it doesn't exist.
-  if [ ! -d "$disk_mount_point" ]; then
-    mkdir -p "$disk_mount_point"
+  if [ "$graphdb_device: data" == "$(file -s "$graphdb_device")" ]; then
+    echo "Creating file system for $graphdb_device"
+    mkfs -t ext4 "$graphdb_device"
   fi
 
-  # Add an entry to the fstab file to automatically mount the disk.
+  mkdir -p "$disk_mount_point"
   if ! grep -q "$graphdb_device" /etc/fstab; then
     echo "$graphdb_device $disk_mount_point ext4 defaults 0 2" >> /etc/fstab
   fi
 
-  # Mount the disk.
   mount "$disk_mount_point"
   echo "The disk at $graphdb_device is now mounted at $disk_mount_point."
-else
-  echo "The disk at $graphdb_device is already mounted."
+
+  echo "Creating data folders"
+  mkdir -p "$disk_mount_point/node" "$disk_mount_point/cluster-proxy"
+  chown -R graphdb:graphdb "$disk_mount_point"
 fi
-
-echo "Creating data folders"
-# Ensure data folders exist.
-mkdir -p $disk_mount_point/node $disk_mount_point/cluster-proxy
-
-# This is required due to ownership being reverted after the disc attachment.
-chown -R graphdb:graphdb $disk_mount_point

--- a/modules/graphdb/templates/07_cluster_setup.sh.tpl
+++ b/modules/graphdb/templates/07_cluster_setup.sh.tpl
@@ -240,7 +240,7 @@ check_license() {
 
   # Check if the response contains the word "free"
   if [[ "$response" == *"free"* ]]; then
-    echo "Free license detecting"
+    echo "Free license detected, EE license required, exiting!"
     exit 1
   fi
 }

--- a/modules/graphdb/templates/README.md
+++ b/modules/graphdb/templates/README.md
@@ -9,6 +9,9 @@ All scripts are designed to be run on AWS EC2 instances and must be executed in 
 Each script is a template file (*.sh.tpl) that contains the necessary commands and configurations.
 These templates are used by Terraform to generate the actual user data scripts deployed to the instances during provisioning.
 
+# 00_wait_node_count.sh.tpl
+This script handles waiting for nodes and disk during instance refresh
+
 # 01_disk_management.sh.tpl
 This script manages the EBS volumes associated with the instance.
 It searches for available volumes and creates new ones if none are found.

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -190,6 +190,39 @@ variable "graphdb_node_count" {
   default     = 3
 }
 
+variable "graphdb_enable_userdata_scripts_on_reboot" {
+  description = "(Experimental) Modifies cloud-config to always run user data scripts on EC2 boot"
+  type        = bool
+}
+
+variable "asg_enable_instance_refresh" {
+  description = "Enables instance refresh for the GraphDB Auto scaling group"
+  type        = bool
+}
+
+variable "asg_instance_refresh_min_healthy_percentage" {
+  description = "Specifies the lower limit on the number of instances that must be in the InService state with a healthy status during an instance replacement activity."
+  type        = number
+  default     = 66
+}
+
+variable "asg_instance_refresh_instance_warmup" {
+  description = "Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period."
+  type        = number
+  default     = 0
+}
+
+variable "asg_instance_refresh_skip_matching" {
+  description = " Replace instances that already have your desired configuration."
+  type        = bool
+  default     = false
+}
+
+variable "asg_instance_refresh_checkpoint_delay" {
+  description = "Number of seconds to wait after a checkpoint."
+  type        = number
+}
+
 variable "lb_enable_private_access" {
   description = "Enable or disable the private access via PrivateLink to the GraphDB Cluster"
   type        = bool

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -46,7 +46,7 @@ variable "lb_unhealthy_threshold" {
 variable "lb_health_check_path" {
   description = "(Optional) The endpoint to check for GraphDB's health status. Defaults to /protocol."
   type        = string
-  default     = "/rest/cluster/node/status"
+  default     = "/protocol"
 }
 
 variable "lb_health_check_interval" {

--- a/variables.tf
+++ b/variables.tf
@@ -441,4 +441,25 @@ variable "lb_access_logs_expiration_days" {
 variable "bucket_replication_destination_region" {
   description = "Define in which Region should the bucket be replicated"
   type        = string
+  default     = null
+}
+
+# ASG instance deployment options
+
+variable "asg_enable_instance_refresh" {
+  description = "Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch_configuration, launch_template, mixed_instances_policy"
+  type        = bool
+  default     = true
+}
+
+variable "asg_instance_refresh_checkpoint_delay" {
+  description = "Number of seconds to wait after a checkpoint."
+  type        = number
+  default     = 3600
+}
+
+variable "graphdb_enable_userdata_scripts_on_reboot" {
+  description = "(Experimental) Modifies cloud-config to always run user data scripts on EC2 boot"
+  type        = bool
+  default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.15"
+      version = "~> 5.49"
     }
 
     random = {


### PR DESCRIPTION
## Description

Enabled instance refresh for GDB ASG 

## Related Issues

GDB-10121

## Changes

Added `ec2:DescribeInstanceStatus` role to `graphdb_instance_volume` policy
Fixed a type-o in `graphdb_auto_scaling_group`
Added `instance_refresh` to `aws_autoscaling_group`
Added new script modules/graphdb/templates/00_wait_node_count.sh.tpl which handles instance refresh to not duplicate volumes or DNS records.
Updated `modules/graphdb/templates/01_disk_management.sh.tpl` to handle rerunning the user data script on reboot. 
Enabled the user data scripts to be ran on EC2 reboot, stop/start, etc. 
Changed `lb_health_check_path` to `/protocol` instead of `/rest/cluster/node/status`
Fixed issue with creating new disks when disk was already attached.
Updated README.md
Added checks for cluster quorum.
Moved the logic for disk mounting so there are no redundant operations.
Renamed `08_node_rejoin.sh.tpl` to `08_node_join.sh.tpl` and removed unnecessary logic.
Refactored `01_disk_management.sh.tpl`
Updated `02_dns_provisioning.sh.tpl` node naming
Added tagging for EC2 instances
AWS module upgrade to 5.49.0


## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
