### PR TITLE
[GDB-10405]Added support to use existing VPC and subnets

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.15, ~> 5.49"
   hashes = [
     "h1:FxPN9X3/R9y952y4c4aLKB7CAHIvMTtfE9Gkmn780Sk=",
+    "h1:RZtXnBRpO4LNmmz0tXJQLa2heqk9VFGblFZtRCZkm/M=",
     "h1:Y3xvYjzBIwYSbcnZDcs6moiy30uxRoY5oT2ExQHKG5A=",
     "zh:0979b07cdeffb868ea605e4bbc008adc7cccb5f3ba1d3a0b794ea3e8fff20932",
     "zh:2121a0a048a1d9419df69f3561e524b7e8a6b74ba0f57bd8948799f12b6ad3a1",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.3.4"
   hashes = [
+    "h1:S3j8poSaLbaftlKq2STBkQEkZH253ZLaHhBHBifdpBQ=",
     "h1:cVIIhnXweOHavu1uV2bdKScTjLbM1WnKM/25wqYBJWo=",
     "h1:iDq03pOzp/UsXya2h+32VOOrvGdJgI9L2/EZJoN9t4A=",
     "zh:09f1f1e1d232da96fbf9513b0fb5263bc2fe9bee85697aa15d40bb93835efbeb",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/random" {
   hashes = [
     "h1:0WIdXFjSCwDr4nwWPYOlaJXselSTwMaKRC4lHDJ1FUE=",
     "h1:1OlP753r4lOKlBprL0HdZGWerm5DCabD5Mli8k8lWAg=",
+    "h1:a+Goawwh6Qtg4/bRWzfDtIdrEFfPlnVy0y4LdUQY3nI=",
     "zh:2a0ec154e39911f19c8214acd6241e469157489fc56b6c739f45fbed5896a176",
     "zh:57f4e553224a5e849c99131f5e5294be3a7adcabe2d867d8a4fef8d0976e0e52",
     "zh:58f09948c608e601bd9d0a9e47dcb78e2b2c13b4bda4d8f097d09152ea9e91c5",

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ logging_enable_bucket_replication = true
 s3_enable_replication_rule = "Enabled"
 ```
 
+#### Deploying in existing VPC
+
+If you have existing VPC created in your account, you can use that VPC to deploy the GraphDB cluster.
+
+What you need to do is to specify values for the following variables
+```hcl
+vpc_id = "vpc-12345678"
+vpc_public_subnet_ids = ["public-subnet-1","public-subnet2","public-subnet-3"]
+vpc_private_subnet_ids = ["private-subnet-1","private-subnet-2","private-subnet-3"]
+```
+
 ## Updating configurations on an active deployment
 
 ### Updating Configurations

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | ec2\_key\_name | (Optional) key pair to use for SSH access to instance | `string` | `null` | no |
 | graphdb\_node\_count | Number of GraphDB nodes to deploy in ASG | `number` | `3` | no |
 | vpc\_dns\_hostnames | Enable or disable DNS hostnames support for the VPC | `bool` | `true` | no |
-| create\_vpc | Enable or disable the creation of the VPC | `bool` | `true` | no |
+| vpc\_id | Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC | `string` | `""` | no |
+| vpc\_public\_subnet\_ids | Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
+| vpc\_private\_subnet\_ids | Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
 | vpc\_private\_subnet\_cidrs | CIDR blocks for private subnets | `list(string)` | ```[ "10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19" ]``` | no |
 | vpc\_public\_subnet\_cidrs | CIDR blocks for public subnets | `list(string)` | ```[ "10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20" ]``` | no |
 | vpc\_cidr\_block | CIDR block for VPC | `string` | `"10.0.0.0/16"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -122,10 +122,22 @@ variable "vpc_dns_hostnames" {
   default     = true
 }
 
-variable "create_vpc" {
-  description = "Enable or disable the creation of the VPC"
-  type        = bool
-  default     = true
+variable "vpc_id" {
+  description = "Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC"
+  type        = string
+  default     = ""
+}
+
+variable "vpc_public_subnet_ids" {
+  description = "Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc_id variable"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_private_subnet_ids" {
+  description = "Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc_id variable"
+  type        = list(string)
+  default     = []
 }
 
 variable "vpc_private_subnet_cidrs" {


### PR DESCRIPTION
## Description

Added support to use existing VPC and subnets.
If you specify VPC ID and subnets IDs it will use them to deploy the GraphDB cluster.

## Related Issues

[GDB-10405]

## Changes

Added two variables for the subnet IDs in public and private networks.
Added conditions to check if there is specified VPC ID and subnet IDs. If they are set it will deploy the GraphDB cluster in that VPC and subnets.

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-10405]: https://ontotext.atlassian.net/browse/GDB-10405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ