### PR TITLE
GDB-10418 Single Node Deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GraphDB AWS Terraform Module Changelog
 
+# 1.2.0
+* Added support for single node deployment
+  * Added new userdata script `10_start_graphdb_services.sh.tpl` for single node setup.
+  * Made cluster-related userdata scripts executable only when graphdb_node_count is greater than 1.
+* Removed hardcoded values from the userdata scripts.
+* Changed the availability tests http_string_type to be calculated based on TLS being enabled.
+
 ## 1.1.0
 * Added support for CMK Keys
 * Added support to use existing VPC and subnets to deploy the GraphDB cluster

--- a/README.md
+++ b/README.md
@@ -447,9 +447,18 @@ If you have existing VPC created in your account, you can use that VPC to deploy
 What you need to do is to specify values for the following variables
 ```hcl
 vpc_id = "vpc-12345678"
-vpc_public_subnet_ids = ["public-subnet-1","public-subnet2","public-subnet-3"]
-vpc_private_subnet_ids = ["private-subnet-1","private-subnet-2","private-subnet-3"]
+vpc_public_subnet_ids = ["subnet-123456","subnet-234567","subnet-345678"]
+vpc_private_subnet_ids = ["subnet-456789","subnet-567891","subnet-678912"]
 ```
+
+## Single Node Deployment
+
+This Terraform module has the ability to deploy a single instance of GraphDB.
+To deploy a single instance you just need to set `graphdb_node_count` to 1, everything else happens automatically.
+
+**Important:** While scaling from a single node deployment to a cluster (e.g., from 1 node to 3 nodes) is possible,
+it is not recommended. Synchronizing the repository across all nodes can be time-consuming,
+potentially causing scripts to time out.
 
 ## Updating configurations on an active deployment
 

--- a/modules/graphdb/templates/00_functions.sh
+++ b/modules/graphdb/templates/00_functions.sh
@@ -6,3 +6,124 @@
 log_with_timestamp() {
   echo "$(date '+%Y-%m-%d %H:%M:%S'): $1"
 }
+
+# Function which waits for all DNS records to be created
+wait_dns_records() {
+  local ZONE_ID="$1"
+  local ROUTE53_ZONE_DNS_NAME="$2"
+  local ASG_NAME="$3"
+  local NODE_COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" --query "AutoScalingGroups[0].DesiredCapacity" --output text)
+  local all_dns_records=($(aws route53 list-resource-record-sets --hosted-zone-id "$${ZONE_ID}" --query "ResourceRecordSets[?contains(Name, '.$${ROUTE53_ZONE_DNS_NAME}') == \`true\`].Name" --output text))
+  local all_dns_records_count="$${#all_dns_records[@]}"
+
+  if [ "$${all_dns_records_count}" -ne $${NODE_COUNT} ]; then
+    sleep 5
+    log_with_timestamp "Private DNS zone record count is $${all_dns_records_count}, expecting $${NODE_COUNT}"
+    wait_dns_records "$ZONE_ID" "$ROUTE53_ZONE_DNS_NAME" "$ASG_NAME"
+  else
+    log_with_timestamp "Private DNS zone record count is $${all_dns_records_count}, expecting $${NODE_COUNT}"
+  fi
+}
+
+# Function which checks if GraphDB is started, we assume it is when the infrastructure endpoint is reached
+check_gdb() {
+  if [ -z "$1" ]; then
+    log_with_timestamp "Error: IP address or hostname is not provided."
+    return 1
+  fi
+
+  local gdb_address="http://$1:7201/rest/monitor/infrastructure"
+  if curl -s --head -u "admin:$${GRAPHDB_ADMIN_PASSWORD}" --fail "$${gdb_address}" >/dev/null; then
+    log_with_timestamp "Success, GraphDB node $${gdb_address} is available"
+    return 0
+  else
+    log_with_timestamp "GraphDB node $${gdb_address} is not available yet"
+    return 1
+  fi
+}
+
+check_all_dns_records() {
+  local ZONE_ID="$1"
+  local ROUTE53_ZONE_DNS_NAME="$2"
+  local RETRY_DELAY="$${3:-5}"  # Default retry delay to 5 seconds if not provided
+
+  # Retrieve existing DNS records
+  local EXISTING_DNS_RECORDS
+  EXISTING_DNS_RECORDS=$(aws route53 list-resource-record-sets --hosted-zone-id "$${ZONE_ID}" --query "ResourceRecordSets[?contains(Name, '.$${ROUTE53_ZONE_DNS_NAME}') == \`true\`].Name")
+
+  # Convert the output into an array
+  local EXISTING_DNS_RECORDS_ARRAY
+  readarray -t EXISTING_DNS_RECORDS_ARRAY <<<"$(echo "$EXISTING_DNS_RECORDS" | jq -r '.[] | rtrimstr(".")')"
+
+  # Wait for all instances to be running
+  for record in "$${EXISTING_DNS_RECORDS_ARRAY[@]}"; do
+    log_with_timestamp "Pinging $record"
+    if [ -n "$record" ]; then
+      while ! check_gdb "$record"; do
+        log_with_timestamp "Waiting for GDB $record to start"
+        sleep "$RETRY_DELAY"
+      done
+    else
+      log_with_timestamp "Error: address is empty."
+    fi
+  done
+
+  log_with_timestamp "All GDB instances are available."
+}
+
+configure_graphdb_security() {
+  local GRAPHDB_PASSWORD=$1
+  local GRAPHDB_URL=$${2:-"http://localhost:7201"}
+
+  IS_SECURITY_ENABLED=$(curl -s -X GET \
+    --header 'Accept: application/json' \
+    -u "admin:$GRAPHDB_PASSWORD" \
+    "$${GRAPHDB_URL}/rest/security")
+
+  # Check if GDB security is enabled
+  if [[ $IS_SECURITY_ENABLED == "true" ]]; then
+    log_with_timestamp "Security is enabled"
+  else
+    # Set the admin password
+    SET_PASSWORD=$(
+      curl --location -s -w "%%{http_code}" \
+        --request PATCH "$${GRAPHDB_URL}/rest/security/users/admin" \
+        --header 'Content-Type: application/json' \
+        --data "{ \"password\": \"$GRAPHDB_PASSWORD\" }"
+    )
+    if [[ "$SET_PASSWORD" == 200 ]]; then
+      log_with_timestamp "Set GraphDB password successfully"
+    else
+      log_with_timestamp "Failed setting GraphDB password. Please check the logs!"
+    fi
+
+    # Enable the security
+    ENABLED_SECURITY=$(curl -X POST -s -w "%%{http_code}" \
+      --header 'Content-Type: application/json' \
+      --header 'Accept: */*' \
+      -d 'true' "$${GRAPHDB_URL}/rest/security")
+
+    if [[ "$ENABLED_SECURITY" == 200 ]]; then
+      log_with_timestamp "Enabled GraphDB security successfully"
+    else
+      log_with_timestamp "Failed enabling GraphDB security. Please check the logs!"
+    fi
+  fi
+}
+
+# Function to check if the GraphDB license has been applied
+check_license() {
+  # Define the URL to check
+  local URL="http://localhost:7201/rest/graphdb-settings/license"
+
+  # Send an HTTP GET request and store the response in a variable
+  local response=$(curl -s "$URL")
+
+  # Check if the response contains the word "free"
+  if [[ "$response" == *"free"* ]]; then
+    log_with_timestamp "Free license detected, EE license required, exiting!"
+    exit 1
+  else
+    echo "License is mounted"
+  fi
+}

--- a/modules/graphdb/templates/08_cluster_setup.sh.tpl
+++ b/modules/graphdb/templates/08_cluster_setup.sh.tpl
@@ -43,41 +43,10 @@ fi
 #   Cluster setup   #
 #####################
 
-# Function which waits for all DNS records to be created
-wait_dns_records() {
-  local all_dns_records=($(aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" --query "ResourceRecordSets[?contains(Name, '.graphdb.cluster') == \`true\`].Name" --output text))
-  local all_dns_records_count="$${#all_dns_records[@]}"
-
-  if [ "$${all_dns_records_count}" -ne $${NODE_COUNT} ]; then
-    sleep 5
-    log_with_timestamp "Private DNS zone record count is $${all_dns_records_count}, expecting $${NODE_COUNT}"
-    wait_dns_records
-  else
-    log_with_timestamp "Private DNS zone record count is $${all_dns_records_count}, expecting $${NODE_COUNT}"
-  fi
-}
-
-# Function which checks if GraphDB is started, we assume it is when the infrastructure endpoint is reached
-check_gdb() {
-  if [ -z "$1" ]; then
-    log_with_timestamp "Error: IP address or hostname is not provided."
-    return 1
-  fi
-
-  local gdb_address="http://$1:7201/rest/monitor/infrastructure"
-  if curl -s --head -u "admin:$${GRAPHDB_ADMIN_PASSWORD}" --fail "$${gdb_address}" >/dev/null; then
-    log_with_timestamp "Success, GraphDB node $${gdb_address} is available"
-    return 0
-  else
-    log_with_timestamp "GraphDB node $${gdb_address} is not available yet"
-    return 1
-  fi
-}
-
-wait_dns_records
+wait_dns_records "${zone_id}" "${route53_zone_dns_name}" "${name}"
 
 # Existing records are returned with . at the end
-EXISTING_DNS_RECORDS=$(aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" --query "ResourceRecordSets[?contains(Name, '.graphdb.cluster') == \`true\`].Name")
+EXISTING_DNS_RECORDS=$(aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" --query "ResourceRecordSets[?contains(Name, '.${route53_zone_dns_name}') == \`true\`].Name")
 # Convert the output into an array
 readarray -t EXISTING_DNS_RECORDS_ARRAY <<<$(echo "$EXISTING_DNS_RECORDS" | jq -r '.[] | rtrimstr(".")')
 # Builds grpc addresses for all nodes registered in Route53
@@ -86,20 +55,7 @@ CLUSTER_ADDRESS_GRPC=$(echo "$EXISTING_DNS_RECORDS" | jq -r '[ .[] | rtrimstr(".
 SORTED_INSTANCE_IDS=($(echo "$${EXISTING_DNS_RECORDS_ARRAY[@]}" | tr ' ' '\n' | sort -n))
 LOWEST_INSTANCE_ID=$${SORTED_INSTANCE_IDS[0]}
 
-# Wait for all instances to be running
-for record in "$${EXISTING_DNS_RECORDS_ARRAY[@]}"; do
-  log_with_timestamp "Pinging $record"
-  if [ -n "$record" ]; then
-    while ! check_gdb "$record"; do
-      log_with_timestamp "Waiting for GDB $record to start"
-      sleep "$RETRY_DELAY"
-    done
-  else
-    log_with_timestamp "Error: address is empty."
-  fi
-done
-
-log_with_timestamp "All GDB instances are available."
+check_all_dns_records "${zone_id}" "${route53_zone_dns_name}" "$RETRY_DELAY"
 
 # Function which finds the cluster Leader node
 find_leader_node() {
@@ -156,7 +112,7 @@ create_cluster() {
     elif [ "$is_cluster" == 503 ]; then
       # Create the GraphDB cluster configuration if it does not exist.
       local cluster_create=$(
-        curl -X POST -s http://localhost:7201/rest/cluster/config \
+        curl -X POST -s "http://node-1.${route53_zone_dns_name}:7201/rest/cluster/config" \
           -o "/dev/null" \
           -w "%%{http_code}" \
           -H 'Content-type: application/json' \
@@ -179,82 +135,12 @@ create_cluster() {
   done
 }
 
-# Function which enables the admin password and enables the security in GraphDB
-enable_security() {
-  echo "#############################################################"
-  echo "#    Changing admin user password and enabling security     #"
-  echo "#############################################################"
-
-  # Set the admin password
-  local set_password=$(
-    curl --location -s -w "%%{http_code}" \
-      --request PATCH 'http://localhost:7200/rest/security/users/admin' \
-      --header 'Content-Type: application/json' \
-      --data "{ \"password\": \"$${GRAPHDB_ADMIN_PASSWORD}\" }"
-  )
-  if [[ "$set_password" == 200 ]]; then
-    log_with_timestamp "Set GraphDB password successfully"
-  else
-    log_with_timestamp "Failed setting GraphDB password. Please check the logs!"
-    return 1
-  fi
-
-  # Enable the security
-  local enable_security=$(
-    curl -X POST -s -w "%%{http_code}" \
-      --header 'Content-Type: application/json' \
-      --header 'Accept: */*' \
-      -d 'true' 'http://localhost:7200/rest/security'
-  )
-
-  if [[ "$enable_security" == 200 ]]; then
-    log_with_timestamp "Enabled GraphDB security successfully"
-  else
-    log_with_timestamp "Failed enabling GraphDB security. Please check the logs!"
-    return 1
-  fi
-}
-
-# Function which checks if the GraphDB security is enabled
-check_security_status() {
-  local is_security_enabled=$(
-    curl -s -X GET \
-      --header 'Accept: application/json' \
-      -u "admin:$${GRAPHDB_ADMIN_PASSWORD}" \
-      'http://localhost:7200/rest/security'
-  )
-
-  # Check if GDB security is enabled
-  if [[ $is_security_enabled == "true" ]]; then
-    log_with_timestamp "Security is enabled"
-  else
-    log_with_timestamp "Security is not enabled"
-    enable_security
-  fi
-}
-
-# Function to check if the GraphDB license has been applied
-check_license() {
-  # Define the URL to check
-  local URL="http://localhost:7201/rest/graphdb-settings/license"
-
-  # Send an HTTP GET request and store the response in a variable
-  local response=$(curl -s "$URL")
-
-  # Check if the response contains the word "free"
-  if [[ "$response" == *"free"* ]]; then
-    log_with_timestamp "Free license detected, EE license required, exiting!"
-    exit 1
-  fi
-}
-
-check_license
-
 #  Only the instance with the lowest ID would attempt to create the cluster
 if [ $NODE_DNS_RECORD == $LOWEST_INSTANCE_ID ]; then
+  check_license
   create_cluster
   find_leader_node
-  check_security_status
+  configure_graphdb_security "$GRAPHDB_ADMIN_PASSWORD"
 else
   log_with_timestamp "Node $NODE_DNS_RECORD is not the lowest instance, skipping cluster creation."
 fi

--- a/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
+++ b/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This script performs the following actions:
+# * Retrieve necessary information from AWS and set variables.
+# * Start and enable GraphDB and GraphDB cluster proxy services.
+# * Check GraphDB availability for all instances and wait for DNS records.
+# * Attempt to create a GraphDB cluster.
+# * Change the admin user password and enable security if the node is the leader.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Imports helper functions
+source /var/lib/cloud/instance/scripts/part-002
+
+NODE_DNS_RECORD=$(cat /var/opt/graphdb/node_dns)
+GRAPHDB_ADMIN_PASSWORD=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/admin_password" --with-decryption --query "Parameter.Value" --output text | base64 -d)
+RETRY_DELAY=5
+
+echo "###########################"
+echo "#    Starting GraphDB     #"
+echo "###########################"
+
+log_with_timestamp "Starting Graphdb"
+systemctl daemon-reload
+systemctl start graphdb
+
+echo "##############################"
+echo "#    Configuring GraphDB     #"
+echo "##############################"
+
+wait_dns_records "${zone_id}" "${route53_zone_dns_name}" "${name}"
+check_all_dns_records "${zone_id}" "${route53_zone_dns_name}" "$RETRY_DELAY"
+configure_graphdb_security "$GRAPHDB_ADMIN_PASSWORD"
+
+echo "###########################"
+echo "#    Script completed     #"
+echo "###########################"

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -84,3 +84,8 @@ variable "lb_access_logs_bucket_name" {
   description = "Define name for the bucket where the access logs will be hosted"
   type        = string
 }
+
+variable "graphdb_node_count" {
+  description = "Number of GraphDB nodes to deploy in ASG"
+  type        = number
+}

--- a/modules/monitoring/alarms.tf
+++ b/modules/monitoring/alarms.tf
@@ -2,6 +2,8 @@
 
 # Attempting to recover metric filter
 resource "aws_cloudwatch_log_metric_filter" "graphdb_attempting_to_recover_metric_filter" {
+  count = var.graphdb_node_count != 1 ? 1 : 0
+
   name           = "mf-${var.resource_name_prefix}-attempting-to-recover"
   pattern        = "successfully replicated registration will not retry"
   log_group_name = aws_cloudwatch_log_group.graphdb_log_group.name
@@ -19,18 +21,20 @@ resource "aws_cloudwatch_log_metric_filter" "graphdb_attempting_to_recover_metri
 # Attempting to recover alarm based on metric filter
 
 resource "aws_cloudwatch_metric_alarm" "graphdb_attempting_to_recover_alarm" {
+  count = var.graphdb_node_count != 1 ? 1 : 0
+
   alarm_name          = "al-${var.resource_name_prefix}-attempting-recover"
   alarm_description   = "Attempting to recover through snapshot replication"
   comparison_operator = "GreaterThanThreshold"
-  metric_name         = aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter[0].metric_transformation[0].namespace
   period              = var.cloudwatch_period
   statistic           = "SampleCount"
   evaluation_periods  = var.cloudwatch_evaluation_periods
   threshold           = "0"
   alarm_actions       = [aws_sns_topic.graphdb_sns_topic.arn]
 
-  depends_on = [aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter]
+  depends_on = [aws_cloudwatch_log_metric_filter.graphdb_attempting_to_recover_metric_filter[0]]
 }
 
 # Log filter for low disk space messages in the logs
@@ -111,6 +115,8 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_cpu_utilization" {
 
 # Alarm for nodes disconnected
 resource "aws_cloudwatch_metric_alarm" "graphdb_nodes_disconnected" {
+  count = var.graphdb_node_count != 1 ? 1 : 0
+
   alarm_name          = "al-${var.resource_name_prefix}-nodes-disconnected"
   alarm_description   = "Alarm will trigger if a node has been disconnected"
   actions_enabled     = true

--- a/modules/monitoring/availability_tests.tf
+++ b/modules/monitoring/availability_tests.tf
@@ -25,8 +25,7 @@ resource "aws_route53_health_check" "graphdb_availability_check" {
   port              = var.route53_availability_port
   request_interval  = var.route53_availability_frequency
   regions           = var.route53_availability_regions
-  resource_path     = var.route53_availability_path
-  search_string     = var.route53_availability_content_match
+  resource_path     = var.graphdb_node_count == 1 ? "/protocol" : "/rest/cluster/node/status"
   type              = var.route53_availability_http_string_type
   measure_latency   = var.route53_availability_measure_latency
 }

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -24,18 +24,6 @@ variable "cloudwatch_alarms_actions_enabled" {
   type        = bool
 }
 
-variable "route53_availability_path" {
-  description = "Path for the web test to be used"
-  type        = string
-  default     = "/rest/cluster/node/status"
-}
-
-variable "route53_availability_content_match" {
-  description = "HTTP Content match for web test availability"
-  type        = string
-  default     = "\"nodeState\":\"LEADER\""
-}
-
 variable "route53_availability_frequency" {
   description = "Interval in seconds between tests. Valid options are 5-30. Default is 30."
   type        = number
@@ -100,7 +88,6 @@ variable "route53_availability_port" {
 variable "route53_availability_http_string_type" {
   description = "HTTP string type: Valid values are HTTP, HTTPS, HTTP_STR_MATCH, HTTPS_STR_MATCH, TCP, CALCULATED, CLOUDWATCH_METRIC and RECOVERY_CONTROL"
   type        = string
-  default     = "HTTP_STR_MATCH"
 }
 
 variable "ssm_parameter_store_ssm_parameter_tier" {
@@ -182,4 +169,9 @@ variable "sns_kms_key_arn" {
 variable "parameter_store_kms_key_arn" {
   description = "ARN of the parameter store KMS Key"
   type        = string
+}
+
+variable "graphdb_node_count" {
+  description = "Number of GraphDB nodes to deploy in ASG"
+  type        = number
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,7 +2,7 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  azs                = slice(data.aws_availability_zones.available.names, 0, 3)
+  azs                = var.graphdb_node_count == 1 ? slice(data.aws_availability_zones.available.names, 0, 1) : slice(data.aws_availability_zones.available.names, 0, 3)
   len_public_subnets = max(length(var.vpc_private_subnet_cidrs))
 
   max_subnet_length = max(

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -6,13 +6,11 @@ variable "resource_name_prefix" {
 variable "vpc_private_subnet_cidrs" {
   description = "CIDR blocks for private subnets"
   type        = list(string)
-  default     = []
 }
 
 variable "vpc_public_subnet_cidrs" {
   description = "CIDR blocks for public subnets"
   type        = list(string)
-  default     = []
 }
 
 variable "vpc_cidr_block" {
@@ -69,4 +67,9 @@ variable "vpc_flow_log_bucket_arn" {
   description = "Define the ARN of the bucket for the VPC flow logs"
   type        = string
   default     = null
+}
+
+variable "graphdb_node_count" {
+  description = "Number of GraphDB nodes to deploy in ASG"
+  type        = number
 }


### PR DESCRIPTION
## Description

Added the ability to deploy a single node GraphDB

## Related Issues

GDB-10418 

## Changes

Added support for single node deployment. 
Removed hardcoded values for DNS zone in userdata scripts
Updated the NSGs ports based on graphdb_node_count
Updated user_data.tf
Changed the name of the LB target group to avoid conflicts when scaling from 1 to 3 AZs
Updated the monitoring, to not deploy cluster alarms when a single node is deployed
Updated the availability_tests
Updated how the VPC azs are calculated based on the graphdb_node_count
Added calculations for the subnets based on the graphdb_node_count

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
