### PR TITLE
update default graphdb version to 10.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * Added `graphdb.external-url.enforce.transactions=true`
 * Removed calculation of `lb_tls_enabled` in the LB module as it is calculated in the main.tf
 * Removed `monitoring_route53_healtcheck_fqdn_url` in favor of `graphdb_external_dns`.
+* Change default EC2 instance type r6i.2xlarge
+* Update default GraphDB version to [10.7.1](https://graphdb.ontotext.com/documentation/10.7/release-notes.html#graphdb-10-7-1)
 
 # 1.2.2
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Note: The options mention above will be appended to the ones set in the user dat
 
 **Customize GraphDB Version**
 ```hcl
-graphdb_version = "10.7.0"
+graphdb_version = "10.7.1"
 ```
 
 **Purge Protection**

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "allowed_inbound_cidrs_ssh" {
 variable "ec2_instance_type" {
   description = "EC2 instance type"
   type        = string
-  default     = "r6g.2xlarge"
+  default     = "r6i.2xlarge"
   nullable    = false
 }
 
@@ -229,7 +229,7 @@ variable "ami_id" {
 variable "graphdb_version" {
   description = "GraphDB version"
   type        = string
-  default     = "10.7.0"
+  default     = "10.7.1"
   nullable    = false
 }
 


### PR DESCRIPTION
## Description

<!-- Please, provide a brief description of the changes you've made in this pull request. -->

## Related Issues

<!-- Links to related issues, fixed issues or partially addressed by this PR. -->

## Changes

* update graphdb to the latest release
* change default EC2 instance type to r6i.2xlarge

## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
