### PR TITLE
Updated default GraphDB version to 10.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -40,3 +40,11 @@ terraform.rc
 # Examples
 examples/**/*.lock.hcl
 .DS_Store
+
+#Certificates
+*.pem
+*.p12
+*.pub
+
+#Licenses
+*.license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 1.2.9
+
+* Update default GraphDB version to [10.8.0](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-0)
+
 ## 1.2.8
 
 * Update default GraphDB Version to [10.7.6](https://graphdb.ontotext.com/documentation/10.7/release-notes.html#graphdb-10-7-6)

--- a/README.md
+++ b/README.md
@@ -86,129 +86,129 @@ Before you begin using this Terraform module, ensure you meet the following prer
 <!-- BEGIN_TF_DOCS -->
 ## Inputs
 
-| Name | Description | Type | Default                                                     | Required |
-|------|-------------|------|-------------------------------------------------------------|:--------:|
-| common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}`                                                        | no |
-| resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a                                                         | yes |
-| aws\_region | AWS region to deploy resources into | `string` | n/a                                                         | yes |
-| override\_owner\_id | Override the default owner ID used for the AMI images | `string` | `null`                                                      | no |
-| deploy\_backup | Deploy backup module | `bool` | `true`                                                      | no |
-| backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"`                                               | no |
-| backup\_retention\_count | Number of backups to keep. | `number` | `7`                                                         | no |
-| backup\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false`                                                     | no |
-| lb\_internal | Whether the load balancer will be internal or public | `bool` | `false`                                                     | no |
-| lb\_deregistration\_delay | Amount time, in seconds, for GraphDB LB target group to wait before changing the state of a deregistering target from draining to unused. | `string` | `300`                                                       | no |
-| lb\_health\_check\_path | The endpoint to check for GraphDB's health status. | `string` | `"/rest/cluster/node/status"`                               | no |
-| lb\_health\_check\_interval | (Optional) Interval in seconds for checking the target group healthcheck. Defaults to 10. | `number` | `10`                                                        | no |
-| lb\_tls\_certificate\_arn | ARN of the TLS certificate, imported in ACM, which will be used for the TLS listener on the load balancer. | `string` | `""`                                                        | no |
-| lb\_tls\_policy | TLS security policy on the listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"`                     | no |
-| allowed\_inbound\_cidrs\_lb | (Optional) List of CIDR blocks to permit inbound traffic from to load balancer | `list(string)` | `null`                                                      | no |
-| allowed\_inbound\_cidrs\_ssh | (Optional) List of CIDR blocks to permit for SSH to GraphDB nodes | `list(string)` | `null`                                                      | no |
-| ec2\_instance\_type | EC2 instance type | `string` | `"r6i.2xlarge"`                                             | no |
-| ec2\_key\_name | (Optional) key pair to use for SSH access to instance | `string` | `null`                                                      | no |
-| graphdb\_node\_count | Number of GraphDB nodes to deploy in ASG | `number` | `3`                                                         | no |
-| vpc\_dns\_hostnames | Enable or disable DNS hostnames support for the VPC | `bool` | `true`                                                      | no |
-| vpc\_id | Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC | `string` | `""`                                                        | no |
-| vpc\_public\_subnet\_ids | Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]`                                                        | no |
-| vpc\_private\_subnet\_ids | Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]`                                                        | no |
-| vpc\_private\_subnet\_cidrs | CIDR blocks for private subnets | `list(string)` | ```[ "10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19" ]```     | no |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
+| resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
+| aws\_region | AWS region to deploy resources into | `string` | n/a | yes |
+| override\_owner\_id | Override the default owner ID used for the AMI images | `string` | `null` | no |
+| deploy\_backup | Deploy backup module | `bool` | `true` | no |
+| backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"` | no |
+| backup\_retention\_count | Number of backups to keep. | `number` | `7` | no |
+| backup\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false` | no |
+| lb\_internal | Whether the load balancer will be internal or public | `bool` | `false` | no |
+| lb\_deregistration\_delay | Amount time, in seconds, for GraphDB LB target group to wait before changing the state of a deregistering target from draining to unused. | `string` | `300` | no |
+| lb\_health\_check\_path | The endpoint to check for GraphDB's health status. | `string` | `"/rest/cluster/node/status"` | no |
+| lb\_health\_check\_interval | (Optional) Interval in seconds for checking the target group healthcheck. Defaults to 10. | `number` | `10` | no |
+| lb\_tls\_certificate\_arn | ARN of the TLS certificate, imported in ACM, which will be used for the TLS listener on the load balancer. | `string` | `""` | no |
+| lb\_tls\_policy | TLS security policy on the listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| allowed\_inbound\_cidrs\_lb | (Optional) List of CIDR blocks to permit inbound traffic from to load balancer | `list(string)` | `null` | no |
+| allowed\_inbound\_cidrs\_ssh | (Optional) List of CIDR blocks to permit for SSH to GraphDB nodes | `list(string)` | `null` | no |
+| ec2\_instance\_type | EC2 instance type | `string` | `"r6i.2xlarge"` | no |
+| ec2\_key\_name | (Optional) key pair to use for SSH access to instance | `string` | `null` | no |
+| graphdb\_node\_count | Number of GraphDB nodes to deploy in ASG | `number` | `3` | no |
+| vpc\_dns\_hostnames | Enable or disable DNS hostnames support for the VPC | `bool` | `true` | no |
+| vpc\_id | Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC | `string` | `""` | no |
+| vpc\_public\_subnet\_ids | Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
+| vpc\_private\_subnet\_ids | Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
+| vpc\_private\_subnet\_cidrs | CIDR blocks for private subnets | `list(string)` | ```[ "10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19" ]``` | no |
 | vpc\_public\_subnet\_cidrs | CIDR blocks for public subnets | `list(string)` | ```[ "10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20" ]``` | no |
-| vpc\_cidr\_block | CIDR block for VPC | `string` | `"10.0.0.0/16"`                                             | no |
-| vpc\_dns\_support | Enable or disable the support of the DNS service | `bool` | `true`                                                      | no |
-| single\_nat\_gateway | Enable or disable the option to have single NAT Gateway. | `bool` | `false`                                                     | no |
-| enable\_nat\_gateway | Enable or disable the creation of the NAT Gateway | `bool` | `true`                                                      | no |
-| vpc\_endpoint\_service\_accept\_connection\_requests | (Required) Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - true or false. | `bool` | `true`                                                      | no |
-| vpc\_endpoint\_service\_allowed\_principals | (Optional) The ARNs of one or more principals allowed to discover the endpoint service. | `list(string)` | `null`                                                      | no |
-| vpc\_enable\_flow\_logs | Enable or disable VPC Flow logs | `bool` | `false`                                                     | no |
-| vpc\_flow\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
-| vpc\_flow\_logs\_expiration\_days | Define the days after which the VPC flow logs should be deleted | `number` | `7`                                                         | no |
-| lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false`                                                     | no |
-| ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null`                                                      | no |
-| graphdb\_version | GraphDB version | `string` | `"10.8.0"`                                                  | no |
-| device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"`                                                | no |
-| ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"`                                                     | no |
-| ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500`                                                       | no |
-| ebs\_volume\_throughput | Throughput for the EBS volumes, used by the GraphDB nodes. | `number` | `250`                                                       | no |
-| ebs\_volume\_iops | IOPS for the EBS volumes, used by the GraphDB nodes. | `number` | `8000`                                                      | no |
-| ebs\_default\_kms\_key | KMS key used for ebs volume encryption. | `string` | `"alias/aws/ebs"`                                           | no |
-| prevent\_resource\_deletion | Defines if applicable resources should be protected from deletion or not | `bool` | `true`                                                      | no |
-| graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | `null`                                                      | no |
-| graphdb\_admin\_password | Password for the 'admin' user in GraphDB. | `string` | `null`                                                      | no |
-| graphdb\_cluster\_token | Cluster token used for authenticating the communication between the nodes. | `string` | `null`                                                      | no |
-| route53\_zone\_dns\_name | DNS name for the private hosted zone in Route 53 | `string` | `"graphdb.cluster"`                                         | no |
-| graphdb\_external\_dns | External domain name where GraphDB will be accessed | `string` | `""`                                                        | no |
-| deploy\_monitoring | Enable or disable toggle for monitoring | `bool` | `false`                                                     | no |
-| monitoring\_route53\_measure\_latency | Enable or disable route53 function to measure latency | `bool` | `false`                                                     | no |
-| monitoring\_actions\_enabled | Enable or disable actions on alarms | `bool` | `false`                                                     | no |
-| monitoring\_sns\_topic\_endpoint | Define an SNS endpoint which will be receiving the alerts via email | `string` | `null`                                                      | no |
-| monitoring\_sns\_protocol | Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS. | `string` | `"email"`                                                   | no |
-| monitoring\_enable\_detailed\_instance\_monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false`                                                     | no |
-| monitoring\_endpoint\_auto\_confirms | Enable or disable endpoint auto confirm subscription to the sns topic | `bool` | `false`                                                     | no |
-| monitoring\_log\_group\_retention\_in\_days | Log group retention in days | `number` | `30`                                                        | no |
-| monitoring\_route53\_health\_check\_aws\_region | Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions. | `string` | `"us-east-1"`                                               | no |
-| monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80`                                                        | no |
-| monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443`                                                       | no |
-| graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null`                                                      | no |
-| graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null`                                                      | no |
-| deploy\_logging\_module | Enable or disable logging module | `bool` | `false`                                                     | no |
-| logging\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false`                                                     | no |
-| s3\_enable\_access\_logs | Enable or disable access logs | `bool` | `false`                                                     | no |
-| s3\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
-| s3\_access\_logs\_expiration\_days | Define the days after which the S3 access logs should be deleted. | `number` | `30`                                                        | no |
-| s3\_expired\_object\_delete\_marker | Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. | `bool` | `true`                                                      | no |
-| s3\_mfa\_delete | Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS | `string` | `"Disabled"`                                                | no |
-| s3\_versioning\_enabled | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `string` | `"Enabled"`                                                 | no |
-| s3\_abort\_multipart\_upload | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7`                                                         | no |
-| s3\_enable\_replication\_rule | Enable or disable S3 bucket replication | `string` | `"Disabled"`                                                | no |
-| lb\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
-| lb\_enable\_access\_logs | Enable or disable access logs for the NLB | `bool` | `false`                                                     | no |
-| lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14`                                                        | no |
-| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null`                                                      | no |
-| asg\_enable\_instance\_refresh | Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch\_configuration, launch\_template, mixed\_instances\_policy | `bool` | `false`                                                     | no |
-| asg\_instance\_refresh\_checkpoint\_delay | Number of seconds to wait after a checkpoint. | `number` | `3600`                                                      | no |
-| graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false`                                                     | no |
-| create\_s3\_kms\_key | Enable creation of KMS key for S3 bucket encryption | `bool` | `false`                                                     | no |
-| s3\_kms\_key\_admin\_arn | ARN of the role or user granted administrative access to the S3 KMS key. | `string` | `""`                                                        | no |
-| s3\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
-| s3\_kms\_default\_key | Define default S3 KMS key | `string` | `"alias/aws/s3"`                                            | no |
-| s3\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-s3-cmk-key"`                                | no |
-| s3\_kms\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
-| s3\_key\_specification | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
-| s3\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
-| s3\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."`                       | no |
-| s3\_external\_kms\_key\_arn | Externally provided KMS CMK | `string` | `""`                                                        | no |
-| parameter\_store\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-param-cmk-key"`                             | no |
-| parameter\_store\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""`                                                        | no |
-| parameter\_store\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}`                                                        | no |
-| parameter\_store\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
-| parameter\_store\_default\_key | Define default key for parameter store if no KMS key is used | `string` | `"alias/aws/ssm"`                                           | no |
-| parameter\_store\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
-| parameter\_store\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
-| parameter\_store\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
-| parameter\_store\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for Parameter Store bucket encryption."`          | no |
-| create\_parameter\_store\_kms\_key | Enable creation of KMS key for Parameter Store encryption | `bool` | `false`                                                     | no |
-| parameter\_store\_external\_kms\_key | Externally provided KMS CMK | `string` | `""`                                                        | no |
-| ebs\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""`                                                        | no |
-| ebs\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}`                                                        | no |
-| ebs\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
-| default\_ebs\_cmk\_alias | The alias for the default Managed key. | `string` | `"alias/aws/ebs"`                                           | no |
-| ebs\_cmk\_alias | Define custom alias for the CMK Key | `string` | `"alias/graphdb-cmk-ebs-key"`                               | no |
-| ebs\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
-| ebs\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
-| ebs\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."`                       | no |
-| ebs\_external\_kms\_key | Externally provided KMS CMK | `string` | `""`                                                        | no |
-| ebs\_key\_enabled | Enable or disable toggle for ebs volume encryption. | `bool` | `true`                                                      | no |
-| create\_ebs\_kms\_key | Creates KMS key for the EBS volumes | `bool` | `false`                                                     | no |
-| create\_sns\_kms\_key | Enable Customer managed keys for encryption. If set to false it will use AWS managed key. | `bool` | `false`                                                     | no |
-| sns\_cmk\_description | Description for the KMS key for the encryption of SNS | `string` | `"KMS CMK Key to encrypt SNS topics"`                       | no |
-| sns\_key\_admin\_arn | ARN of the role or user granted administrative access to the SNS KMS key. | `string` | `""`                                                        | no |
-| deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
-| sns\_external\_kms\_key | ARN of the external KMS key that will be used for encryption of SNS topics | `string` | `""`                                                        | no |
-| sns\_cmk\_key\_alias | The alias for the SNS CMK key. | `string` | `"alias/graphdb-sns-cmk-key-alias"`                         | no |
-| sns\_default\_kms\_key | ARN of the default KMS key that will be used for encryption of SNS topics | `string` | `"alias/aws/sns"`                                           | no |
-| sns\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
-| sns\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
-| sns\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
+| vpc\_cidr\_block | CIDR block for VPC | `string` | `"10.0.0.0/16"` | no |
+| vpc\_dns\_support | Enable or disable the support of the DNS service | `bool` | `true` | no |
+| single\_nat\_gateway | Enable or disable the option to have single NAT Gateway. | `bool` | `false` | no |
+| enable\_nat\_gateway | Enable or disable the creation of the NAT Gateway | `bool` | `true` | no |
+| vpc\_endpoint\_service\_accept\_connection\_requests | (Required) Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - true or false. | `bool` | `true` | no |
+| vpc\_endpoint\_service\_allowed\_principals | (Optional) The ARNs of one or more principals allowed to discover the endpoint service. | `list(string)` | `null` | no |
+| vpc\_enable\_flow\_logs | Enable or disable VPC Flow logs | `bool` | `false` | no |
+| vpc\_flow\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
+| vpc\_flow\_logs\_expiration\_days | Define the days after which the VPC flow logs should be deleted | `number` | `7` | no |
+| lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false` | no |
+| ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null` | no |
+| graphdb\_version | GraphDB version | `string` | `"10.8.0"` | no |
+| device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"` | no |
+| ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"` | no |
+| ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500` | no |
+| ebs\_volume\_throughput | Throughput for the EBS volumes, used by the GraphDB nodes. | `number` | `250` | no |
+| ebs\_volume\_iops | IOPS for the EBS volumes, used by the GraphDB nodes. | `number` | `8000` | no |
+| ebs\_default\_kms\_key | KMS key used for ebs volume encryption. | `string` | `"alias/aws/ebs"` | no |
+| prevent\_resource\_deletion | Defines if applicable resources should be protected from deletion or not | `bool` | `true` | no |
+| graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | `null` | no |
+| graphdb\_admin\_password | Password for the 'admin' user in GraphDB. | `string` | `null` | no |
+| graphdb\_cluster\_token | Cluster token used for authenticating the communication between the nodes. | `string` | `null` | no |
+| route53\_zone\_dns\_name | DNS name for the private hosted zone in Route 53 | `string` | `"graphdb.cluster"` | no |
+| graphdb\_external\_dns | External domain name where GraphDB will be accessed | `string` | `""` | no |
+| deploy\_monitoring | Enable or disable toggle for monitoring | `bool` | `false` | no |
+| monitoring\_route53\_measure\_latency | Enable or disable route53 function to measure latency | `bool` | `false` | no |
+| monitoring\_actions\_enabled | Enable or disable actions on alarms | `bool` | `false` | no |
+| monitoring\_sns\_topic\_endpoint | Define an SNS endpoint which will be receiving the alerts via email | `string` | `null` | no |
+| monitoring\_sns\_protocol | Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS. | `string` | `"email"` | no |
+| monitoring\_enable\_detailed\_instance\_monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
+| monitoring\_endpoint\_auto\_confirms | Enable or disable endpoint auto confirm subscription to the sns topic | `bool` | `false` | no |
+| monitoring\_log\_group\_retention\_in\_days | Log group retention in days | `number` | `30` | no |
+| monitoring\_route53\_health\_check\_aws\_region | Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions. | `string` | `"us-east-1"` | no |
+| monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80` | no |
+| monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443` | no |
+| graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null` | no |
+| graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null` | no |
+| deploy\_logging\_module | Enable or disable logging module | `bool` | `false` | no |
+| logging\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false` | no |
+| s3\_enable\_access\_logs | Enable or disable access logs | `bool` | `false` | no |
+| s3\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
+| s3\_access\_logs\_expiration\_days | Define the days after which the S3 access logs should be deleted. | `number` | `30` | no |
+| s3\_expired\_object\_delete\_marker | Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. | `bool` | `true` | no |
+| s3\_mfa\_delete | Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS | `string` | `"Disabled"` | no |
+| s3\_versioning\_enabled | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `string` | `"Enabled"` | no |
+| s3\_abort\_multipart\_upload | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
+| s3\_enable\_replication\_rule | Enable or disable S3 bucket replication | `string` | `"Disabled"` | no |
+| lb\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
+| lb\_enable\_access\_logs | Enable or disable access logs for the NLB | `bool` | `false` | no |
+| lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14` | no |
+| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null` | no |
+| asg\_enable\_instance\_refresh | Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch\_configuration, launch\_template, mixed\_instances\_policy | `bool` | `false` | no |
+| asg\_instance\_refresh\_checkpoint\_delay | Number of seconds to wait after a checkpoint. | `number` | `3600` | no |
+| graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false` | no |
+| create\_s3\_kms\_key | Enable creation of KMS key for S3 bucket encryption | `bool` | `false` | no |
+| s3\_kms\_key\_admin\_arn | ARN of the role or user granted administrative access to the S3 KMS key. | `string` | `""` | no |
+| s3\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
+| s3\_kms\_default\_key | Define default S3 KMS key | `string` | `"alias/aws/s3"` | no |
+| s3\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-s3-cmk-key"` | no |
+| s3\_kms\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
+| s3\_key\_specification | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| s3\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
+| s3\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."` | no |
+| s3\_external\_kms\_key\_arn | Externally provided KMS CMK | `string` | `""` | no |
+| parameter\_store\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-param-cmk-key"` | no |
+| parameter\_store\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""` | no |
+| parameter\_store\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
+| parameter\_store\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
+| parameter\_store\_default\_key | Define default key for parameter store if no KMS key is used | `string` | `"alias/aws/ssm"` | no |
+| parameter\_store\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
+| parameter\_store\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| parameter\_store\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
+| parameter\_store\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for Parameter Store bucket encryption."` | no |
+| create\_parameter\_store\_kms\_key | Enable creation of KMS key for Parameter Store encryption | `bool` | `false` | no |
+| parameter\_store\_external\_kms\_key | Externally provided KMS CMK | `string` | `""` | no |
+| ebs\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""` | no |
+| ebs\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
+| ebs\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
+| default\_ebs\_cmk\_alias | The alias for the default Managed key. | `string` | `"alias/aws/ebs"` | no |
+| ebs\_cmk\_alias | Define custom alias for the CMK Key | `string` | `"alias/graphdb-cmk-ebs-key"` | no |
+| ebs\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| ebs\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
+| ebs\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."` | no |
+| ebs\_external\_kms\_key | Externally provided KMS CMK | `string` | `""` | no |
+| ebs\_key\_enabled | Enable or disable toggle for ebs volume encryption. | `bool` | `true` | no |
+| create\_ebs\_kms\_key | Creates KMS key for the EBS volumes | `bool` | `false` | no |
+| create\_sns\_kms\_key | Enable Customer managed keys for encryption. If set to false it will use AWS managed key. | `bool` | `false` | no |
+| sns\_cmk\_description | Description for the KMS key for the encryption of SNS | `string` | `"KMS CMK Key to encrypt SNS topics"` | no |
+| sns\_key\_admin\_arn | ARN of the role or user granted administrative access to the SNS KMS key. | `string` | `""` | no |
+| deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
+| sns\_external\_kms\_key | ARN of the external KMS key that will be used for encryption of SNS topics | `string` | `""` | no |
+| sns\_cmk\_key\_alias | The alias for the SNS CMK key. | `string` | `"alias/graphdb-sns-cmk-key-alias"` | no |
+| sns\_default\_kms\_key | ARN of the default KMS key that will be used for encryption of SNS topics | `string` | `"alias/aws/sns"` | no |
+| sns\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| sns\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
+| sns\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
 <!-- END_TF_DOCS -->
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -86,129 +86,129 @@ Before you begin using this Terraform module, ensure you meet the following prer
 <!-- BEGIN_TF_DOCS -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
-| resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
-| aws\_region | AWS region to deploy resources into | `string` | n/a | yes |
-| override\_owner\_id | Override the default owner ID used for the AMI images | `string` | `null` | no |
-| deploy\_backup | Deploy backup module | `bool` | `true` | no |
-| backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"` | no |
-| backup\_retention\_count | Number of backups to keep. | `number` | `7` | no |
-| backup\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false` | no |
-| lb\_internal | Whether the load balancer will be internal or public | `bool` | `false` | no |
-| lb\_deregistration\_delay | Amount time, in seconds, for GraphDB LB target group to wait before changing the state of a deregistering target from draining to unused. | `string` | `300` | no |
-| lb\_health\_check\_path | The endpoint to check for GraphDB's health status. | `string` | `"/rest/cluster/node/status"` | no |
-| lb\_health\_check\_interval | (Optional) Interval in seconds for checking the target group healthcheck. Defaults to 10. | `number` | `10` | no |
-| lb\_tls\_certificate\_arn | ARN of the TLS certificate, imported in ACM, which will be used for the TLS listener on the load balancer. | `string` | `""` | no |
-| lb\_tls\_policy | TLS security policy on the listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
-| allowed\_inbound\_cidrs\_lb | (Optional) List of CIDR blocks to permit inbound traffic from to load balancer | `list(string)` | `null` | no |
-| allowed\_inbound\_cidrs\_ssh | (Optional) List of CIDR blocks to permit for SSH to GraphDB nodes | `list(string)` | `null` | no |
-| ec2\_instance\_type | EC2 instance type | `string` | `"r6i.2xlarge"` | no |
-| ec2\_key\_name | (Optional) key pair to use for SSH access to instance | `string` | `null` | no |
-| graphdb\_node\_count | Number of GraphDB nodes to deploy in ASG | `number` | `3` | no |
-| vpc\_dns\_hostnames | Enable or disable DNS hostnames support for the VPC | `bool` | `true` | no |
-| vpc\_id | Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC | `string` | `""` | no |
-| vpc\_public\_subnet\_ids | Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
-| vpc\_private\_subnet\_ids | Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]` | no |
-| vpc\_private\_subnet\_cidrs | CIDR blocks for private subnets | `list(string)` | ```[ "10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19" ]``` | no |
+| Name | Description | Type | Default                                                     | Required |
+|------|-------------|------|-------------------------------------------------------------|:--------:|
+| common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}`                                                        | no |
+| resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a                                                         | yes |
+| aws\_region | AWS region to deploy resources into | `string` | n/a                                                         | yes |
+| override\_owner\_id | Override the default owner ID used for the AMI images | `string` | `null`                                                      | no |
+| deploy\_backup | Deploy backup module | `bool` | `true`                                                      | no |
+| backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"`                                               | no |
+| backup\_retention\_count | Number of backups to keep. | `number` | `7`                                                         | no |
+| backup\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false`                                                     | no |
+| lb\_internal | Whether the load balancer will be internal or public | `bool` | `false`                                                     | no |
+| lb\_deregistration\_delay | Amount time, in seconds, for GraphDB LB target group to wait before changing the state of a deregistering target from draining to unused. | `string` | `300`                                                       | no |
+| lb\_health\_check\_path | The endpoint to check for GraphDB's health status. | `string` | `"/rest/cluster/node/status"`                               | no |
+| lb\_health\_check\_interval | (Optional) Interval in seconds for checking the target group healthcheck. Defaults to 10. | `number` | `10`                                                        | no |
+| lb\_tls\_certificate\_arn | ARN of the TLS certificate, imported in ACM, which will be used for the TLS listener on the load balancer. | `string` | `""`                                                        | no |
+| lb\_tls\_policy | TLS security policy on the listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"`                     | no |
+| allowed\_inbound\_cidrs\_lb | (Optional) List of CIDR blocks to permit inbound traffic from to load balancer | `list(string)` | `null`                                                      | no |
+| allowed\_inbound\_cidrs\_ssh | (Optional) List of CIDR blocks to permit for SSH to GraphDB nodes | `list(string)` | `null`                                                      | no |
+| ec2\_instance\_type | EC2 instance type | `string` | `"r6i.2xlarge"`                                             | no |
+| ec2\_key\_name | (Optional) key pair to use for SSH access to instance | `string` | `null`                                                      | no |
+| graphdb\_node\_count | Number of GraphDB nodes to deploy in ASG | `number` | `3`                                                         | no |
+| vpc\_dns\_hostnames | Enable or disable DNS hostnames support for the VPC | `bool` | `true`                                                      | no |
+| vpc\_id | Specify the VPC ID if you want to use existing VPC. If left empty it will create a new VPC | `string` | `""`                                                        | no |
+| vpc\_public\_subnet\_ids | Define the Subnet IDs for the public subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]`                                                        | no |
+| vpc\_private\_subnet\_ids | Define the Subnet IDs for the private subnets that are deployed within the specified VPC in the vpc\_id variable | `list(string)` | `[]`                                                        | no |
+| vpc\_private\_subnet\_cidrs | CIDR blocks for private subnets | `list(string)` | ```[ "10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19" ]```     | no |
 | vpc\_public\_subnet\_cidrs | CIDR blocks for public subnets | `list(string)` | ```[ "10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20" ]``` | no |
-| vpc\_cidr\_block | CIDR block for VPC | `string` | `"10.0.0.0/16"` | no |
-| vpc\_dns\_support | Enable or disable the support of the DNS service | `bool` | `true` | no |
-| single\_nat\_gateway | Enable or disable the option to have single NAT Gateway. | `bool` | `false` | no |
-| enable\_nat\_gateway | Enable or disable the creation of the NAT Gateway | `bool` | `true` | no |
-| vpc\_endpoint\_service\_accept\_connection\_requests | (Required) Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - true or false. | `bool` | `true` | no |
-| vpc\_endpoint\_service\_allowed\_principals | (Optional) The ARNs of one or more principals allowed to discover the endpoint service. | `list(string)` | `null` | no |
-| vpc\_enable\_flow\_logs | Enable or disable VPC Flow logs | `bool` | `false` | no |
-| vpc\_flow\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
-| vpc\_flow\_logs\_expiration\_days | Define the days after which the VPC flow logs should be deleted | `number` | `7` | no |
-| lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false` | no |
-| ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null` | no |
-| graphdb\_version | GraphDB version | `string` | `"10.7.6"` | no |
-| device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"` | no |
-| ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"` | no |
-| ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500` | no |
-| ebs\_volume\_throughput | Throughput for the EBS volumes, used by the GraphDB nodes. | `number` | `250` | no |
-| ebs\_volume\_iops | IOPS for the EBS volumes, used by the GraphDB nodes. | `number` | `8000` | no |
-| ebs\_default\_kms\_key | KMS key used for ebs volume encryption. | `string` | `"alias/aws/ebs"` | no |
-| prevent\_resource\_deletion | Defines if applicable resources should be protected from deletion or not | `bool` | `true` | no |
-| graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | `null` | no |
-| graphdb\_admin\_password | Password for the 'admin' user in GraphDB. | `string` | `null` | no |
-| graphdb\_cluster\_token | Cluster token used for authenticating the communication between the nodes. | `string` | `null` | no |
-| route53\_zone\_dns\_name | DNS name for the private hosted zone in Route 53 | `string` | `"graphdb.cluster"` | no |
-| graphdb\_external\_dns | External domain name where GraphDB will be accessed | `string` | `""` | no |
-| deploy\_monitoring | Enable or disable toggle for monitoring | `bool` | `false` | no |
-| monitoring\_route53\_measure\_latency | Enable or disable route53 function to measure latency | `bool` | `false` | no |
-| monitoring\_actions\_enabled | Enable or disable actions on alarms | `bool` | `false` | no |
-| monitoring\_sns\_topic\_endpoint | Define an SNS endpoint which will be receiving the alerts via email | `string` | `null` | no |
-| monitoring\_sns\_protocol | Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS. | `string` | `"email"` | no |
-| monitoring\_enable\_detailed\_instance\_monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
-| monitoring\_endpoint\_auto\_confirms | Enable or disable endpoint auto confirm subscription to the sns topic | `bool` | `false` | no |
-| monitoring\_log\_group\_retention\_in\_days | Log group retention in days | `number` | `30` | no |
-| monitoring\_route53\_health\_check\_aws\_region | Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions. | `string` | `"us-east-1"` | no |
-| monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80` | no |
-| monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443` | no |
-| graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null` | no |
-| graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null` | no |
-| deploy\_logging\_module | Enable or disable logging module | `bool` | `false` | no |
-| logging\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false` | no |
-| s3\_enable\_access\_logs | Enable or disable access logs | `bool` | `false` | no |
-| s3\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
-| s3\_access\_logs\_expiration\_days | Define the days after which the S3 access logs should be deleted. | `number` | `30` | no |
-| s3\_expired\_object\_delete\_marker | Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. | `bool` | `true` | no |
-| s3\_mfa\_delete | Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS | `string` | `"Disabled"` | no |
-| s3\_versioning\_enabled | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `string` | `"Enabled"` | no |
-| s3\_abort\_multipart\_upload | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
-| s3\_enable\_replication\_rule | Enable or disable S3 bucket replication | `string` | `"Disabled"` | no |
-| lb\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"` | no |
-| lb\_enable\_access\_logs | Enable or disable access logs for the NLB | `bool` | `false` | no |
-| lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14` | no |
-| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null` | no |
-| asg\_enable\_instance\_refresh | Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch\_configuration, launch\_template, mixed\_instances\_policy | `bool` | `false` | no |
-| asg\_instance\_refresh\_checkpoint\_delay | Number of seconds to wait after a checkpoint. | `number` | `3600` | no |
-| graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false` | no |
-| create\_s3\_kms\_key | Enable creation of KMS key for S3 bucket encryption | `bool` | `false` | no |
-| s3\_kms\_key\_admin\_arn | ARN of the role or user granted administrative access to the S3 KMS key. | `string` | `""` | no |
-| s3\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
-| s3\_kms\_default\_key | Define default S3 KMS key | `string` | `"alias/aws/s3"` | no |
-| s3\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-s3-cmk-key"` | no |
-| s3\_kms\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
-| s3\_key\_specification | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| s3\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
-| s3\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."` | no |
-| s3\_external\_kms\_key\_arn | Externally provided KMS CMK | `string` | `""` | no |
-| parameter\_store\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-param-cmk-key"` | no |
-| parameter\_store\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""` | no |
-| parameter\_store\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
-| parameter\_store\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
-| parameter\_store\_default\_key | Define default key for parameter store if no KMS key is used | `string` | `"alias/aws/ssm"` | no |
-| parameter\_store\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
-| parameter\_store\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| parameter\_store\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
-| parameter\_store\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for Parameter Store bucket encryption."` | no |
-| create\_parameter\_store\_kms\_key | Enable creation of KMS key for Parameter Store encryption | `bool` | `false` | no |
-| parameter\_store\_external\_kms\_key | Externally provided KMS CMK | `string` | `""` | no |
-| ebs\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""` | no |
-| ebs\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
-| ebs\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
-| default\_ebs\_cmk\_alias | The alias for the default Managed key. | `string` | `"alias/aws/ebs"` | no |
-| ebs\_cmk\_alias | Define custom alias for the CMK Key | `string` | `"alias/graphdb-cmk-ebs-key"` | no |
-| ebs\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| ebs\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
-| ebs\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."` | no |
-| ebs\_external\_kms\_key | Externally provided KMS CMK | `string` | `""` | no |
-| ebs\_key\_enabled | Enable or disable toggle for ebs volume encryption. | `bool` | `true` | no |
-| create\_ebs\_kms\_key | Creates KMS key for the EBS volumes | `bool` | `false` | no |
-| create\_sns\_kms\_key | Enable Customer managed keys for encryption. If set to false it will use AWS managed key. | `bool` | `false` | no |
-| sns\_cmk\_description | Description for the KMS key for the encryption of SNS | `string` | `"KMS CMK Key to encrypt SNS topics"` | no |
-| sns\_key\_admin\_arn | ARN of the role or user granted administrative access to the SNS KMS key. | `string` | `""` | no |
-| deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30` | no |
-| sns\_external\_kms\_key | ARN of the external KMS key that will be used for encryption of SNS topics | `string` | `""` | no |
-| sns\_cmk\_key\_alias | The alias for the SNS CMK key. | `string` | `"alias/graphdb-sns-cmk-key-alias"` | no |
-| sns\_default\_kms\_key | ARN of the default KMS key that will be used for encryption of SNS topics | `string` | `"alias/aws/sns"` | no |
-| sns\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| sns\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
-| sns\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
+| vpc\_cidr\_block | CIDR block for VPC | `string` | `"10.0.0.0/16"`                                             | no |
+| vpc\_dns\_support | Enable or disable the support of the DNS service | `bool` | `true`                                                      | no |
+| single\_nat\_gateway | Enable or disable the option to have single NAT Gateway. | `bool` | `false`                                                     | no |
+| enable\_nat\_gateway | Enable or disable the creation of the NAT Gateway | `bool` | `true`                                                      | no |
+| vpc\_endpoint\_service\_accept\_connection\_requests | (Required) Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - true or false. | `bool` | `true`                                                      | no |
+| vpc\_endpoint\_service\_allowed\_principals | (Optional) The ARNs of one or more principals allowed to discover the endpoint service. | `list(string)` | `null`                                                      | no |
+| vpc\_enable\_flow\_logs | Enable or disable VPC Flow logs | `bool` | `false`                                                     | no |
+| vpc\_flow\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
+| vpc\_flow\_logs\_expiration\_days | Define the days after which the VPC flow logs should be deleted | `number` | `7`                                                         | no |
+| lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false`                                                     | no |
+| ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null`                                                      | no |
+| graphdb\_version | GraphDB version | `string` | `"10.8.0"`                                                  | no |
+| device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"`                                                | no |
+| ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"`                                                     | no |
+| ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500`                                                       | no |
+| ebs\_volume\_throughput | Throughput for the EBS volumes, used by the GraphDB nodes. | `number` | `250`                                                       | no |
+| ebs\_volume\_iops | IOPS for the EBS volumes, used by the GraphDB nodes. | `number` | `8000`                                                      | no |
+| ebs\_default\_kms\_key | KMS key used for ebs volume encryption. | `string` | `"alias/aws/ebs"`                                           | no |
+| prevent\_resource\_deletion | Defines if applicable resources should be protected from deletion or not | `bool` | `true`                                                      | no |
+| graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | `null`                                                      | no |
+| graphdb\_admin\_password | Password for the 'admin' user in GraphDB. | `string` | `null`                                                      | no |
+| graphdb\_cluster\_token | Cluster token used for authenticating the communication between the nodes. | `string` | `null`                                                      | no |
+| route53\_zone\_dns\_name | DNS name for the private hosted zone in Route 53 | `string` | `"graphdb.cluster"`                                         | no |
+| graphdb\_external\_dns | External domain name where GraphDB will be accessed | `string` | `""`                                                        | no |
+| deploy\_monitoring | Enable or disable toggle for monitoring | `bool` | `false`                                                     | no |
+| monitoring\_route53\_measure\_latency | Enable or disable route53 function to measure latency | `bool` | `false`                                                     | no |
+| monitoring\_actions\_enabled | Enable or disable actions on alarms | `bool` | `false`                                                     | no |
+| monitoring\_sns\_topic\_endpoint | Define an SNS endpoint which will be receiving the alerts via email | `string` | `null`                                                      | no |
+| monitoring\_sns\_protocol | Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS. | `string` | `"email"`                                                   | no |
+| monitoring\_enable\_detailed\_instance\_monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false`                                                     | no |
+| monitoring\_endpoint\_auto\_confirms | Enable or disable endpoint auto confirm subscription to the sns topic | `bool` | `false`                                                     | no |
+| monitoring\_log\_group\_retention\_in\_days | Log group retention in days | `number` | `30`                                                        | no |
+| monitoring\_route53\_health\_check\_aws\_region | Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions. | `string` | `"us-east-1"`                                               | no |
+| monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80`                                                        | no |
+| monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443`                                                       | no |
+| graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null`                                                      | no |
+| graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null`                                                      | no |
+| deploy\_logging\_module | Enable or disable logging module | `bool` | `false`                                                     | no |
+| logging\_enable\_bucket\_replication | Enable or disable S3 bucket replication | `bool` | `false`                                                     | no |
+| s3\_enable\_access\_logs | Enable or disable access logs | `bool` | `false`                                                     | no |
+| s3\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
+| s3\_access\_logs\_expiration\_days | Define the days after which the S3 access logs should be deleted. | `number` | `30`                                                        | no |
+| s3\_expired\_object\_delete\_marker | Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. | `bool` | `true`                                                      | no |
+| s3\_mfa\_delete | Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS | `string` | `"Disabled"`                                                | no |
+| s3\_versioning\_enabled | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `string` | `"Enabled"`                                                 | no |
+| s3\_abort\_multipart\_upload | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7`                                                         | no |
+| s3\_enable\_replication\_rule | Enable or disable S3 bucket replication | `string` | `"Disabled"`                                                | no |
+| lb\_access\_logs\_lifecycle\_rule\_status | Define status of the S3 lifecycle rule. Possible options are enabled or disabled. | `string` | `"Disabled"`                                                | no |
+| lb\_enable\_access\_logs | Enable or disable access logs for the NLB | `bool` | `false`                                                     | no |
+| lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14`                                                        | no |
+| bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null`                                                      | no |
+| asg\_enable\_instance\_refresh | Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch\_configuration, launch\_template, mixed\_instances\_policy | `bool` | `false`                                                     | no |
+| asg\_instance\_refresh\_checkpoint\_delay | Number of seconds to wait after a checkpoint. | `number` | `3600`                                                      | no |
+| graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false`                                                     | no |
+| create\_s3\_kms\_key | Enable creation of KMS key for S3 bucket encryption | `bool` | `false`                                                     | no |
+| s3\_kms\_key\_admin\_arn | ARN of the role or user granted administrative access to the S3 KMS key. | `string` | `""`                                                        | no |
+| s3\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
+| s3\_kms\_default\_key | Define default S3 KMS key | `string` | `"alias/aws/s3"`                                            | no |
+| s3\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-s3-cmk-key"`                                | no |
+| s3\_kms\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
+| s3\_key\_specification | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
+| s3\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
+| s3\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."`                       | no |
+| s3\_external\_kms\_key\_arn | Externally provided KMS CMK | `string` | `""`                                                        | no |
+| parameter\_store\_cmk\_alias | The alias for the CMK key. | `string` | `"alias/graphdb-param-cmk-key"`                             | no |
+| parameter\_store\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""`                                                        | no |
+| parameter\_store\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}`                                                        | no |
+| parameter\_store\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
+| parameter\_store\_default\_key | Define default key for parameter store if no KMS key is used | `string` | `"alias/aws/ssm"`                                           | no |
+| parameter\_store\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
+| parameter\_store\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
+| parameter\_store\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
+| parameter\_store\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for Parameter Store bucket encryption."`          | no |
+| create\_parameter\_store\_kms\_key | Enable creation of KMS key for Parameter Store encryption | `bool` | `false`                                                     | no |
+| parameter\_store\_external\_kms\_key | Externally provided KMS CMK | `string` | `""`                                                        | no |
+| ebs\_key\_admin\_arn | ARN of the key administrator role for Parameter Store | `string` | `""`                                                        | no |
+| ebs\_key\_tags | A map of tags to assign to the resources. | `map(string)` | `{}`                                                        | no |
+| ebs\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
+| default\_ebs\_cmk\_alias | The alias for the default Managed key. | `string` | `"alias/aws/ebs"`                                           | no |
+| ebs\_cmk\_alias | Define custom alias for the CMK Key | `string` | `"alias/graphdb-cmk-ebs-key"`                               | no |
+| ebs\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
+| ebs\_key\_deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
+| ebs\_cmk\_description | Description for the KMS Key | `string` | `"KMS key for S3 bucket encryption."`                       | no |
+| ebs\_external\_kms\_key | Externally provided KMS CMK | `string` | `""`                                                        | no |
+| ebs\_key\_enabled | Enable or disable toggle for ebs volume encryption. | `bool` | `true`                                                      | no |
+| create\_ebs\_kms\_key | Creates KMS key for the EBS volumes | `bool` | `false`                                                     | no |
+| create\_sns\_kms\_key | Enable Customer managed keys for encryption. If set to false it will use AWS managed key. | `bool` | `false`                                                     | no |
+| sns\_cmk\_description | Description for the KMS key for the encryption of SNS | `string` | `"KMS CMK Key to encrypt SNS topics"`                       | no |
+| sns\_key\_admin\_arn | ARN of the role or user granted administrative access to the SNS KMS key. | `string` | `""`                                                        | no |
+| deletion\_window\_in\_days | The waiting period, specified in number of days for AWS to delete the KMS key(Between 7 and 30). | `number` | `30`                                                        | no |
+| sns\_external\_kms\_key | ARN of the external KMS key that will be used for encryption of SNS topics | `string` | `""`                                                        | no |
+| sns\_cmk\_key\_alias | The alias for the SNS CMK key. | `string` | `"alias/graphdb-sns-cmk-key-alias"`                         | no |
+| sns\_default\_kms\_key | ARN of the default KMS key that will be used for encryption of SNS topics | `string` | `"alias/aws/sns"`                                           | no |
+| sns\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"`                                       | no |
+| sns\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true`                                                      | no |
+| sns\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true`                                                      | no |
 <!-- END_TF_DOCS -->
 
 ## Usage
@@ -294,7 +294,7 @@ Note: The options mention above will be appended to the ones set in the user dat
 **Customize GraphDB Version**
 
 ```hcl
-graphdb_version = "10.7.6"
+graphdb_version = "10.8.0"
 ```
 
 **Purge Protection**

--- a/variables.tf
+++ b/variables.tf
@@ -229,7 +229,7 @@ variable "ami_id" {
 variable "graphdb_version" {
   description = "GraphDB version"
   type        = string
-  default     = "10.7.6"
+  default     = "10.8.0"
   nullable    = false
 }
 


### PR DESCRIPTION
## Description

Updated default GraphDB version to 10.8.0

## Changes

Updated default GraphDB version to 10.8.0

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
