### PR TITLE
GDB-11661 Skipped provisioning of Route53 hosted zone when a single node is deployed

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.87.0"
   constraints = "~> 5.87.0"
   hashes = [
+    "h1:2A5UZnERIQPA9PMmbdfgFNqbYjUxk10J7W6d5QcTCM4=",
     "h1:IYq3by7O/eJuXzJwOF920z2nZEkw08PkDFdw2xkyhrs=",
     "zh:017f237466875c919330b9e214fb33af14fffbff830d3755e8976d8fa3c963c2",
     "zh:0776d1e60aa93c85ecbb01144aed2789c8e180bb0f1c811a0aba17ca7247b26c",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.3.5"
   hashes = [
     "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
+    "h1:wbw64JlCobcQCAdlzHpxksQ1GabewTW1yxnACBVZh4A=",
     "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
     "zh:348664d9a900f7baf7b091cf94d657e4c968b240d31d9e162086724e6afc19d5",
     "zh:5a876a468ffabff0299f8348e719cb704daf81a4867f8c6892f3c3c4add2c755",
@@ -47,6 +49,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
+    "h1:N2IQabOiZC5eCEGrfgVS6ChVmRDh1ENtfHgGjnV4QQQ=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added ability to specify IAM role to be assumed in provider.tf
 * Added ability to use existing Route53 Private hosted zone
 * Updated Provider version in versions.tf
+* Removed the provisioning of Route53 Hosted zone when deploying a single node.
 
 ## 1.3.3
 

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ This module allows you to configure the AWS provider to assume a role in another
 
 ```hcl
 assume_role_arn           = "arn:aws:iam::accountID:role/rolename"
-assume_role_external_id = "exampleid"
+assume_role_external_id = "exampleId"
 assume_role_session_name = "session"
 ```
 
@@ -525,9 +525,11 @@ vpc_private_subnet_ids = ["subnet-456789","subnet-567891","subnet-678912"]
 This Terraform module can deploy a single instance of GraphDB.
 To do this, set `graphdb_node_count` to `1`, and the rest will be handled automatically.
 
-**Important:** While it is possible to scale from a single node to a cluster deployment (e.g., from 1 node to 3 nodes),
-it is not recommended. Synchronizing the repository across all nodes can be time-consuming and may cause scripts
-to time out.
+**Important:** Scaling from a single-node deployment to a cluster deployment (e.g., changing `graphdb_node_count` from 1 to 3)
+is not fully automated. While the Terraform module will allow you to scale up and create 3 instances,
+the cluster will not be formed unless you terminate the initial node.
+
+**Please note that this operation is disruptive, and there is a risk that things may not go as expected.**
 
 ## Updating configurations on an active deployment
 

--- a/main.tf
+++ b/main.tf
@@ -203,9 +203,9 @@ module "monitoring" {
 
   count = var.deploy_monitoring ? 1 : 0
 
-  resource_name_prefix                   = var.resource_name_prefix
-  aws_region                             = var.aws_region
-  route53_availability_check_region      = var.monitoring_route53_health_check_aws_region
+  resource_name_prefix = var.resource_name_prefix
+  aws_region           = var.aws_region
+
   cloudwatch_alarms_actions_enabled      = var.monitoring_actions_enabled
   sns_topic_endpoint                     = var.deploy_monitoring ? var.monitoring_sns_topic_endpoint : null
   sns_endpoint_auto_confirms             = var.monitoring_endpoint_auto_confirms
@@ -222,13 +222,17 @@ module "monitoring" {
   cmk_key_alias                          = var.sns_cmk_key_alias
   parameter_store_kms_key_arn            = local.calculated_parameter_store_kms_key_arn
   cloudwatch_log_group_retention_in_days = var.monitoring_log_group_retention_in_days
-  route53_availability_request_url       = var.graphdb_external_dns
-  route53_availability_measure_latency   = var.monitoring_route53_measure_latency
-  sns_kms_key_arn                        = local.calculated_sns_kms_key_arn
-  graphdb_node_count                     = var.graphdb_node_count
-  route53_availability_http_string_type  = upper(local.calculated_protocol)
-  lb_tls_certificate_arn                 = var.lb_tls_certificate_arn
-  lb_dns_name                            = module.load_balancer.lb_dns_name != "" ? module.load_balancer.lb_dns_name : null
+
+  route53_availability_check_region     = var.monitoring_route53_health_check_aws_region
+  route53_availability_request_url      = var.graphdb_node_count > 1 ? var.graphdb_external_dns : module.load_balancer.lb_dns_name
+  route53_availability_measure_latency  = var.graphdb_node_count > 1 ? var.monitoring_route53_measure_latency : false
+  route53_availability_http_string_type = upper(local.calculated_protocol)
+
+  sns_kms_key_arn    = local.calculated_sns_kms_key_arn
+  graphdb_node_count = var.graphdb_node_count
+
+  lb_tls_certificate_arn = var.lb_tls_certificate_arn
+  lb_dns_name            = module.load_balancer.lb_dns_name != "" ? module.load_balancer.lb_dns_name : null
 }
 
 module "graphdb" {
@@ -305,8 +309,7 @@ module "graphdb" {
   ebs_default_kms_key = var.default_ebs_cmk_alias
 
   # DNS
-
-  route53_zone_dns_name    = var.route53_zone_dns_name
+  route53_zone_dns_name    = var.graphdb_node_count > 1 ? var.route53_zone_dns_name : null
   route53_existing_zone_id = var.route53_existing_zone_id
 
   # User data scripts

--- a/modules/graphdb/dns.tf
+++ b/modules/graphdb/dns.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "graphdb_zone" {
-  count = var.route53_existing_zone_id == null ? 1 : 0
+  count = (var.route53_existing_zone_id == null || var.graphdb_node_count > 1) ? 1 : 0
 
   name = var.route53_zone_dns_name
 

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -158,8 +158,17 @@ data "aws_iam_policy_document" "graphdb_instance_volume_tagging" {
     }
   }
 }
+resource "aws_iam_role_policy" "graphdb_route53_instance_registration" {
+  count = var.graphdb_node_count > 1 ? 1 : 0
+
+  name   = "${var.resource_name_prefix}-route53-instance-registration"
+  role   = aws_iam_role.graphdb_iam_role.id
+  policy = data.aws_iam_policy_document.graphdb_route53_instance_registration[count.index].json
+}
 
 data "aws_iam_policy_document" "graphdb_route53_instance_registration" {
+  count = var.graphdb_node_count > 1 ? 1 : 0
+
   statement {
     effect = "Allow"
 
@@ -169,15 +178,9 @@ data "aws_iam_policy_document" "graphdb_route53_instance_registration" {
     ]
 
     resources = [
-      "arn:aws:route53:::hostedzone/${aws_route53_zone.graphdb_zone != [] ? aws_route53_zone.graphdb_zone[0].zone_id : var.route53_existing_zone_id}"
+      "arn:aws:route53:::hostedzone/${aws_route53_zone.graphdb_zone != [] ? aws_route53_zone.graphdb_zone[count.index].zone_id : var.route53_existing_zone_id}"
     ]
   }
-}
-
-resource "aws_iam_role_policy" "graphdb_route53_instance_registration" {
-  name   = "${var.resource_name_prefix}-route53-instance-registration"
-  role   = aws_iam_role.graphdb_iam_role.id
-  policy = data.aws_iam_policy_document.graphdb_route53_instance_registration.json
 }
 
 data "aws_iam_policy_document" "graphdb_s3_replication_policy_logging" {

--- a/modules/graphdb/nsg.tf
+++ b/modules/graphdb/nsg.tf
@@ -19,7 +19,7 @@ resource "aws_security_group_rule" "graphdb_internal_http" {
 }
 
 resource "aws_security_group_rule" "graphdb_internal_raft" {
-  count = var.graphdb_node_count != 1 ? 1 : 0
+  count = var.graphdb_node_count > 1 ? 1 : 0
 
   description       = "Allow GraphDB proxies and nodes to communicate (Raft)."
   security_group_id = aws_security_group.graphdb_security_group.id

--- a/modules/graphdb/outputs.tf
+++ b/modules/graphdb/outputs.tf
@@ -44,7 +44,8 @@ output "graphdb_userdata_base64_encoded" {
 
 output "route53_zone_id" {
   description = "ID of the private hosted zone for GraphDB DNS resolving"
-  value       = var.route53_existing_zone_id != "" ? var.route53_existing_zone_id : (aws_route53_zone.graphdb_zone != [] ? aws_route53_zone.graphdb_zone[0].zone_id : null)
+  value       = var.route53_existing_zone_id != "" ? var.route53_existing_zone_id : (var.graphdb_node_count > 1 && length(aws_route53_zone.graphdb_zone) > 0 ? aws_route53_zone.graphdb_zone[0].zone_id : null)
+
 }
 
 # Parameter store KMS

--- a/modules/graphdb/templates/00_functions.sh
+++ b/modules/graphdb/templates/00_functions.sh
@@ -187,3 +187,26 @@ check_license() {
     echo "License is mounted"
   fi
 }
+
+# Function which waits for GraphDB to start, checking every 10 seconds up to 5 minutes
+wait_for_local_gdb() {
+  local gdb_address="http://localhost:7201/protocol"
+  local max_wait_time=300  # 5 minutes
+  local wait_interval=10   # Check every 10 seconds
+  local elapsed_time=0
+
+  while [ $elapsed_time -lt $max_wait_time ]; do
+    if curl -s --head -u "admin:$${GRAPHDB_ADMIN_PASSWORD}" --fail "$${gdb_address}" >/dev/null; then
+      log_with_timestamp "Success, GraphDB instance is available at $gdb_address"
+      return 0  # Success
+    fi
+
+    # Wait for the specified interval
+    sleep $wait_interval
+    elapsed_time=$((elapsed_time + wait_interval))
+    log_with_timestamp "Waiting for GraphDB to start, elapsed time: $${elapsed_time}s"
+  done
+
+  log_with_timestamp "Error: GraphDB instance at $gdb_address not available after waiting for $max_wait_time seconds."
+  return 1
+}

--- a/modules/graphdb/templates/08_cluster_setup.sh.tpl
+++ b/modules/graphdb/templates/08_cluster_setup.sh.tpl
@@ -25,7 +25,7 @@ echo "#    Starting GraphDB     #"
 echo "###########################"
 
 # Don't attempt to form a cluster if the node count is 1
-if [ "$${NODE_COUNT}" == 1 ]; then
+if [[ "$${NODE_COUNT}" -eq 1 ]]; then
   log_with_timestamp "Starting Graphdb"
   systemctl daemon-reload
   systemctl start graphdb

--- a/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
+++ b/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
 # This script performs the following actions:
-# * Retrieve necessary information from AWS and set variables.
-# * Start and enable GraphDB and GraphDB cluster proxy services.
-# * Check GraphDB availability for all instances and wait for DNS records.
-# * Attempt to create a GraphDB cluster.
-# * Change the admin user password and enable security if the node is the leader.
+# * Retrieves necessary information from AWS, such as the GraphDB admin password.
+# * Starts and enables the GraphDB service and GraphDB cluster proxy services.
+# * Waits for the availability of the local GraphDB instance.
+# * Configures the GraphDB instance for secure operation using the provided admin password.
 
 set -o errexit
 set -o nounset
@@ -14,9 +13,7 @@ set -o pipefail
 # Imports helper functions
 source /var/lib/cloud/instance/scripts/part-002
 
-NODE_DNS_RECORD=$(cat /var/opt/graphdb/node_dns)
 GRAPHDB_ADMIN_PASSWORD=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/admin_password" --with-decryption --query "Parameter.Value" --output text | base64 -d)
-RETRY_DELAY=5
 
 echo "###########################"
 echo "#    Starting GraphDB     #"
@@ -30,8 +27,7 @@ echo "##############################"
 echo "#    Configuring GraphDB     #"
 echo "##############################"
 
-wait_dns_records "${zone_id}" "${route53_zone_dns_name}" "${name}"
-check_all_dns_records "${zone_id}" "${route53_zone_dns_name}" "$RETRY_DELAY"
+wait_for_local_gdb
 configure_graphdb_security "$GRAPHDB_ADMIN_PASSWORD"
 
 echo "###########################"

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -48,7 +48,7 @@ resource "aws_lb_target_group" "graphdb_lb_target_group" {
     unhealthy_threshold = var.lb_unhealthy_threshold
     protocol            = "HTTP"
     port                = 7201
-    path                = var.graphdb_node_count != 1 ? var.lb_health_check_path : "/protocol"
+    path                = var.graphdb_node_count > 1 ? var.lb_health_check_path : "/protocol"
     interval            = var.lb_health_check_interval
   }
 }

--- a/modules/monitoring/alarms.tf
+++ b/modules/monitoring/alarms.tf
@@ -2,7 +2,7 @@
 
 # Attempting to recover metric filter
 resource "aws_cloudwatch_log_metric_filter" "graphdb_attempting_to_recover_metric_filter" {
-  count = var.graphdb_node_count != 1 ? 1 : 0
+  count = var.graphdb_node_count > 1 ? 1 : 0
 
   name           = "mf-${var.resource_name_prefix}-attempting-to-recover"
   pattern        = "successfully replicated registration will not retry"
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_metric_filter" "graphdb_attempting_to_recover_metri
 # Attempting to recover alarm based on metric filter
 
 resource "aws_cloudwatch_metric_alarm" "graphdb_attempting_to_recover_alarm" {
-  count = var.graphdb_node_count != 1 ? 1 : 0
+  count = var.graphdb_node_count > 1 ? 1 : 0
 
   alarm_name          = "al-${var.resource_name_prefix}-attempting-recover"
   alarm_description   = "Attempting to recover through snapshot replication"
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_cpu_utilization" {
 
 # Alarm for nodes disconnected
 resource "aws_cloudwatch_metric_alarm" "graphdb_nodes_disconnected" {
-  count = var.graphdb_node_count != 1 ? 1 : 0
+  count = var.graphdb_node_count > 1 ? 1 : 0
 
   alarm_name          = "al-${var.resource_name_prefix}-nodes-disconnected"
   alarm_description   = "Alarm will trigger if a node has been disconnected"


### PR DESCRIPTION
## Description

GDB-11661 Skipped provisioning of Route53 hosted zone when a single node is deployed

## Related Issues

GDB-11661 

## Changes

* Made the Route53 hosted zone deployment dynamic based on `graphdb_node_count`. 
* Updated user data scripts to not run DNS configurations if a single node is deployed. 
* Changed the availability test endpoint address when deploying a single node. 

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
