### PR TITLE
[GDB-11623] Parse /etc/graphdb/graphdb.env and modify GDB_JAVA_OPTS inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # IDEs
-
+*.iml
 .idea/
 
 # Local .terraform directories

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -85,10 +85,11 @@ fi
 # Appends environment overrides to GDB_JAVA_OPTS
 if [[ $SSM_PARAMETERS == *"/${name}/graphdb/graphdb_java_options"* ]]; then
   extra_graphdb_java_options="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_java_options" --with-decryption | jq -r .Parameter.Value)"
-  (
-    source /etc/graphdb/graphdb.env
-    echo "GDB_JAVA_OPTS=\"$GDB_JAVA_OPTS $extra_graphdb_java_options\"" >> /etc/graphdb/graphdb.env
-  )
+  if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
+    sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
+  else
+    echo "GDB_JAVA_OPTS=$extra_garphdb_java_options" > /etc/graphdb/graphdb.env
+  fi
 fi
 
 log_with_timestamp "Completed applying overrides"


### PR DESCRIPTION
## Description

Parses GDB_JAVA_OPTS variable from /etc/graphdb/graphdb.env, instead of source the file

## Related Issues
[GDB-11623](https://ontotext.atlassian.net/browse/GDB-11623)

## Changes
Changes `04_gdb_conf_overrides.sh.tpl` to parse `/etc/graphdb/graphdb.env` and modify GDB_JAVA_OPTS inline  

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11623]: https://ontotext.atlassian.net/browse/GDB-11623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ