### PR TITLE
[GDB-11619] Restrict graphdb_instance_ssm to resources part of GDB deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * Updated Provider version in versions.tf
 * Removed the provisioning of Route53 Hosted zone when deploying a single node.
 * Added ability to use custom principal for EBS Admin Role and Param Store Admin role via assume_role_principal_arn variable
-
+* Updated graphdb_instance_ssm policy in iam.tf - added restrictions on ssm:DescribeParameters to only allow usage on graphdb-related resources.
+* Updated graphdb_instance_ssm polict in iam.tf - restricted kms actions to Decrypt only
 
 ## 1.3.3
 

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "graphdb_instance_ssm" {
 
     actions = [
       "ssm:DescribeParameters",
-      "kms:*"
+      "kms:Decrypt"
     ]
 
     resources = [

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "graphdb_instance_ssm" {
     ]
 
     resources = [
-      "arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:*"
+      "arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:/${var.resource_name_prefix}/graphdb/*"
     ]
   }
 }


### PR DESCRIPTION
## Description

Refactors graphdb -> graphdb_iam.tf to restrict `graphdb_instance_ssm` policy resource to only SSM resources part of the deployment

## Related Issues

[GDB-11619](https://ontotext.atlassian.net/browse/GDB-11619)

## Changes

1. Set the resources for `graphdb_instance_ssm` to `"arn:aws:ssm:${var.aws_region}:${var.aws_subscription_id}:/${var.resource_name_prefix}/graphdb/*"` which should limit to any resources defined in the `graphdb` logical group.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11619]: https://ontotext.atlassian.net/browse/GDB-11619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ