### PR TITLE
Fixes typo in 04_gdb_conf_overrides.sh.tpl. Reorder check

### DIFF
--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -85,10 +85,10 @@ fi
 # Appends environment overrides to GDB_JAVA_OPTS
 if [[ $SSM_PARAMETERS == *"/${name}/graphdb/graphdb_java_options"* ]]; then
   extra_graphdb_java_options="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_java_options" --with-decryption | jq -r .Parameter.Value)"
-  if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
+  if grep GDB_JAVA_OPTS /etc/graphdb/graphdb.env &>/dev/null; then
     sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
   else
-    echo "GDB_JAVA_OPTS=$extra_garphdb_java_options" > /etc/graphdb/graphdb.env
+    echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env
   fi
 fi
 


### PR DESCRIPTION
## Description

Fixes a typo in `04_gdb_conf_overrides.sh.tpl`, and an invalid `grep` check which fails to configure GraphDB. Regressions introduced in https://github.com/Ontotext-AD/terraform-aws-graphdb/pull/82


## Related Issues

[GDB-11623](https://ontotext.atlassian.net/browse/GDB-11623)

## Changes

- Fixes the typo, which would occur if no `GDB_JAVA_OPTS` are set in `/etc/graphdb/graphdb.env`  (this case is not reachable by default)
- Fixes the reordering of `grep` logic to check if `GDB_JAVA_OPTS` is set.

## Screenshots
![image](https://github.com/user-attachments/assets/d75d617d-e5bd-41f1-bf0c-5acbcdb916cb)
![image](https://github.com/user-attachments/assets/66189eba-855b-403c-9aa2-93878c0786f9)


## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.

[GDB-11623]: https://ontotext.atlassian.net/browse/GDB-11623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ