### PR TITLE
Remove access to AWS cli for users other than root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Updated graphdb_instance_ssm policy in iam.tf - added restrictions on ssm:DescribeParameters to only allow usage on graphdb-related resources.
 * Updated graphdb_instance_ssm polict in iam.tf - restricted kms actions to Decrypt only
 * Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users 
+* Removed access to aws cli for users other than root
 
 ## 1.3.3
 

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -85,7 +85,7 @@ data "cloudinit_config" "graphdb_user_data" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = templatefile("${path.module}/templates/06_linux_overrides.sh.tpl", {})
+    content = templatefile("${path.module}/templates/06_linux_overrides.sh.tpl", {})
   }
 
   part {
@@ -151,5 +151,15 @@ data "cloudinit_config" "graphdb_user_data" {
         - [scripts-user, always]
     EOF
     }
+  }
+
+  # 12 Make aws-cli accessible only for root user
+  part {
+    content_type = "text/x-shellscript"
+    content      = <<-EOF
+      #!/bin/bash
+      set -euo pipefail
+      chmod -R og-rwx /usr/local/aws-cli/
+    EOF
   }
 }

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -85,7 +85,7 @@ data "cloudinit_config" "graphdb_user_data" {
 
   part {
     content_type = "text/x-shellscript"
-    content = templatefile("${path.module}/templates/06_linux_overrides.sh.tpl", {})
+    content      = templatefile("${path.module}/templates/06_linux_overrides.sh.tpl", {})
   }
 
   part {


### PR DESCRIPTION
## Description

For security purposes, make AWS cli, located in `/usr/local/aws-cli` accessible only by `root` user

## Related Issues

[GDB-11621](https://ontotext.atlassian.net/browse/GDB-11621)

## Changes

Make `/usr/local/aws-cli` accessible only by the root user

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11621]: https://ontotext.atlassian.net/browse/GDB-11621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ