### PR TITLE
GDB-11905 Reworked memory alarms for GDB instances in ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,6 +227,7 @@ module "monitoring" {
   route53_availability_request_url      = var.graphdb_node_count > 1 ? var.graphdb_external_dns : module.load_balancer.lb_dns_name
   route53_availability_measure_latency  = var.graphdb_node_count > 1 ? var.monitoring_route53_measure_latency : false
   route53_availability_http_string_type = upper(local.calculated_protocol)
+  route53_zone_dns_name                 = var.graphdb_node_count > 1 ? var.route53_zone_dns_name : null
 
   sns_kms_key_arn    = local.calculated_sns_kms_key_arn
   graphdb_node_count = var.graphdb_node_count

--- a/modules/graphdb/templates/01_wait_node_count.sh.tpl
+++ b/modules/graphdb/templates/01_wait_node_count.sh.tpl
@@ -30,7 +30,9 @@ if [ "$GRAPHDB_NODE_COUNT" -gt 1 ]; then
   echo "GraphDB node count is greater than 1. Running wait_asg_nodes..."
   wait_for_asg_nodes "$ASG_NAME"
 else
-  echo "GraphDB node count is 1 or less. Skipping wait_asg_nodes."
+  echo "GraphDB node count is 1. Skipping wait_asg_nodes."
+  # Sets hostname to node-1
+  hostnamectl set-hostname "node-1"
 fi
 
 instance_refresh_status=$(aws autoscaling describe-instance-refreshes --auto-scaling-group-name "$ASG_NAME" --query 'InstanceRefreshes[?Status==`InProgress`]' --output json)

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -31,7 +31,6 @@ aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${na
 GRAPHDB_CLUSTER_TOKEN="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/cluster_token" --with-decryption | jq -r .Parameter.Value | base64 -d)"
 NODE_COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ${name} --query "AutoScalingGroups[0].DesiredCapacity" --output text)
 
-
 # graphdb.external-url.enforce.transactions: determines whether it is necessary to rewrite the Location header when no proxy is configured.
 # This is required because when working with the GDB transaction endpoint it returns an erroneous URL with HTTP protocol instead of HTTPS
 if [ "$NODE_COUNT" -eq 1 ]; then

--- a/modules/monitoring/cloudwatch_agent_config.json.tpl
+++ b/modules/monitoring/cloudwatch_agent_config.json.tpl
@@ -159,7 +159,8 @@
                 "measurement": [
                     "mem_used_percent",
                     "mem_free",
-                    "mem_available_percent"
+                    "mem_available_percent",
+                    "mem_total"
                 ],
                 "metrics_collection_interval": 10
             }

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -188,6 +188,11 @@ variable "route53_availability_https_port" {
   default     = 443
 }
 
+variable "route53_zone_dns_name" {
+  description = "DNS name for the private hosted zone in Route 53"
+  type        = string
+}
+
 variable "lb_tls_certificate_arn" {
   description = "ARN of the TLS certificate, imported in ACM, which will be used for the TLS listener on the load balancer."
   type        = string


### PR DESCRIPTION
## Description
Reworked memory alarms for GDB instances in ASG
The memory alarm now tracks the GDB heap memory instead of the VM total memory 
Enabled gathering of `mem_total` metric by CW Agent

## Related Issues

GDB-11905 

## Changes

Reworked memory alarms for GDB instances in ASG
Updated the `cloudwatch_agent_config.json.tpl` to include `mem_total`
Updated user data scripts to set hostname if single node deployment. 

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
