### PR TITLE
Add restrictions on ec2:CreateTags, ec2:CreateVolume and ec2:AttachVolume. Add deploy_tag variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 * Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users
 * Removed access to aws cli for users other than root
 * Added a toggle for enabling/disabling the availability tests in CloudWatch
-* Added new variable, deploy_tag to be used for tagging resources as part of the deployment. This allows for stricter IAM policies on certain (dangerous) actions
+* Added new variable, deployment_restriction_tag to be used for tagging resources as part of the deployment. This allows for stricter IAM policies on certain (dangerous) actions
 * Changed graphdb_instance_volume policy to restrict ec2:AttachVolume and ec2:CreateVolume for only specifically tagged volumes
-* Extended graphdb_instance_volume_tagging by adding an additional constraint on ec2:CreateTags to allow instances that are already tagged with deploy_tag to be tagged with a Name
+* Extended graphdb_instance_volume_tagging by adding an additional constraint on ec2:CreateTags to allow instances that are already tagged with deployment_restriction_tag to be tagged with a Name
 
 ## 1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@
 * Removed the provisioning of Route53 Hosted zone when deploying a single node.
 * Added ability to use custom principal for EBS Admin Role and Param Store Admin role via assume_role_principal_arn variable
 * Updated graphdb_instance_ssm policy in iam.tf - added restrictions on ssm:DescribeParameters to only allow usage on graphdb-related resources.
-* Updated graphdb_instance_ssm polict in iam.tf - restricted kms actions to Decrypt only
-* Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users 
+* Updated graphdb_instance_ssm policy in iam.tf - restricted kms actions to Decrypt only
+* Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users
 * Removed access to aws cli for users other than root
 * Added a toggle for enabling/disabling the availability tests in CloudWatch
+* Added new variable, deploy_tag to be used for tagging resources as part of the deployment. This allows for stricter IAM policies on certain (dangerous) actions
+* Changed graphdb_instance_volume policy to restrict ec2:AttachVolume and ec2:CreateVolume for only specifically tagged volumes
+* Extended graphdb_instance_volume_tagging by adding an additional constraint on ec2:CreateTags to allow instances that are already tagged with deploy_tag to be tagged with a Name
 
 ## 1.3.3
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| deploy\_tag | Deployment tag. | `string` | n/a | yes |
+| deploy\_tag | Deployment tag used to restrict access via IAM policies | `string` | n/a | yes |
 | common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
 | resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
 | aws\_region | AWS region to deploy resources into | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| deploy\_tag | Deployment tag. | `string` | n/a | yes |
 | common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
 | resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
 | aws\_region | AWS region to deploy resources into | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| deploy\_tag | Deployment tag used to restrict access via IAM policies | `string` | n/a | yes |
+| deployment\_restriction\_tag | Deployment tag used to restrict access via IAM policies | `string` | `"deploymentTag"` | no |
 | common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
 | resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
 | aws\_region | AWS region to deploy resources into | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -241,6 +241,7 @@ module "graphdb" {
   source = "./modules/graphdb"
 
   resource_name_prefix      = var.resource_name_prefix
+  deploy_tag                = var.deploy_tag
   aws_region                = data.aws_region.current.name
   aws_subscription_id       = data.aws_caller_identity.current.account_id
   assume_role_principal_arn = var.assume_role_principal_arn

--- a/main.tf
+++ b/main.tf
@@ -240,11 +240,11 @@ module "monitoring" {
 module "graphdb" {
   source = "./modules/graphdb"
 
-  resource_name_prefix      = var.resource_name_prefix
-  deploy_tag                = var.deploy_tag
-  aws_region                = data.aws_region.current.name
-  aws_subscription_id       = data.aws_caller_identity.current.account_id
-  assume_role_principal_arn = var.assume_role_principal_arn
+  resource_name_prefix       = var.resource_name_prefix
+  deployment_restriction_tag = var.deployment_restriction_tag
+  aws_region                 = data.aws_region.current.name
+  aws_subscription_id        = data.aws_caller_identity.current.account_id
+  assume_role_principal_arn  = var.assume_role_principal_arn
 
   # Networking
 

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -107,6 +107,7 @@ data "aws_iam_policy_document" "graphdb_describe_resources" {
 data "aws_iam_policy_document" "graphdb_instance_volume" {
   statement {
     effect = "Allow"
+
     actions = [
       "ec2:DescribeVolumes",
       "ec2:MonitorInstances",
@@ -128,6 +129,7 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
       "kms:EnableKey",
       "kms:DisableKey"
     ]
+
     resources = [
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*",
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
@@ -138,22 +140,27 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
   }
   statement {
     effect = "Allow"
+
     actions = [
       "ec2:CreateVolume"
     ]
+
     resources = [
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
     ]
+
     condition {
       test     = "StringEquals"
       values = [ var.deploy_tag ]
       variable = "aws:ResourceTag/DeployTag"
     }
+
     condition {
       test     = "StringEquals"
       values = [ "${var.resource_name_prefix}-graphdb-data" ]
       variable = "aws:ResourceTag/Name"
     }
+
     condition {
       test = "ForAllValues:StringEquals"
       values = [ "Name", "DeployTag" ]
@@ -164,13 +171,16 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
 
   statement {
     effect = "Allow"
+
     actions = [
       "ec2:AttachVolume",
     ]
+
     resources = [
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*",
-      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
     ]
+
     condition {
       test     = "StringEquals"
       values = [ var.deploy_tag ]

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -108,11 +108,8 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
   statement {
     effect = "Allow"
     actions = [
-      "ec2:CreateVolume",
-      "ec2:AttachVolume",
       "ec2:DescribeVolumes",
       "ec2:MonitorInstances",
-      "ec2:CreateTags",
       "kms:Encrypt",
       "kms:Decrypt",
       "kms:GenerateDataKey",
@@ -137,6 +134,48 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:network-interface/*",
       "arn:aws:kms:${var.aws_region}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
+
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateVolume"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      values = [ var.deploy_tag ]
+      variable = "aws:ResourceTag/DeployTag"
+    }
+    condition {
+      test     = "StringEquals"
+      values = [ "${var.resource_name_prefix}-graphdb-data" ]
+      variable = "aws:ResourceTag/Name"
+    }
+    condition {
+      test = "ForAllValues:StringEquals"
+      values = [ "Name", "DeployTag" ]
+      variable = "aws:TagKeys"
+    }
+
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*",
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      values = [ var.deploy_tag ]
+      variable = "aws:ResourceTag/DeployTag"
+    }
   }
 }
 
@@ -159,6 +198,34 @@ data "aws_iam_policy_document" "graphdb_instance_volume_tagging" {
       values = [
         "CreateVolume",
         "CreateSnapshot"
+      ]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateTags"
+    ]
+
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/DeployTag"
+      values = [
+        var.deploy_tag
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/Name"
+      values = [
+        "${var.resource_name_prefix}:*"
       ]
     }
   }

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -151,7 +151,7 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
 
     condition {
       test     = "StringEquals"
-      values   = [var.deploy_tag]
+      values   = [var.deployment_restriction_tag]
       variable = "aws:RequestTag/DeployTag"
     }
 
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
 
     condition {
       test     = "StringEquals"
-      values   = [var.deploy_tag]
+      values   = [var.deployment_restriction_tag]
       variable = "aws:ResourceTag/DeployTag"
     }
   }
@@ -227,7 +227,7 @@ data "aws_iam_policy_document" "graphdb_instance_volume_tagging" {
       test     = "StringEquals"
       variable = "aws:ResourceTag/DeployTag"
       values = [
-        var.deploy_tag
+        var.deployment_restriction_tag
       ]
     }
 

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -151,19 +151,19 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
 
     condition {
       test     = "StringEquals"
-      values = [ var.deploy_tag ]
-      variable = "aws:ResourceTag/DeployTag"
+      values   = [var.deploy_tag]
+      variable = "aws:RequestTag/DeployTag"
     }
 
     condition {
       test     = "StringEquals"
-      values = [ "${var.resource_name_prefix}-graphdb-data" ]
-      variable = "aws:ResourceTag/Name"
+      values   = ["${var.resource_name_prefix}-graphdb-data"]
+      variable = "aws:RequestTag/Name"
     }
 
     condition {
-      test = "ForAllValues:StringEquals"
-      values = [ "Name", "DeployTag" ]
+      test     = "ForAllValues:StringEquals"
+      values   = ["Name", "DeployTag"]
       variable = "aws:TagKeys"
     }
 
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "graphdb_instance_volume" {
 
     condition {
       test     = "StringEquals"
-      values = [ var.deploy_tag ]
+      values   = [var.deploy_tag]
       variable = "aws:ResourceTag/DeployTag"
     }
   }

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -117,7 +117,7 @@ resource "aws_autoscaling_group" "graphdb_auto_scaling_group" {
 
   tag {
     key                 = "DeployTag"
-    value               = var.deploy_tag
+    value               = var.deployment_restriction_tag
     propagate_at_launch = true
   }
 

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -115,6 +115,12 @@ resource "aws_autoscaling_group" "graphdb_auto_scaling_group" {
     }
   }
 
+  tag {
+    key                 = "DeployTag"
+    value               = var.deploy_tag
+    propagate_at_launch = true
+  }
+
   dynamic "tag" {
     for_each = data.aws_default_tags.current.tags
     content {

--- a/modules/graphdb/templates/02_disk_management.sh.tpl
+++ b/modules/graphdb/templates/02_disk_management.sh.tpl
@@ -37,7 +37,7 @@ create_volume() {
     --size "${ebs_volume_size}" \
     --iops "${ebs_volume_iops}" \
     --throughput "${ebs_volume_throughput}" \
-    --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${name}-graphdb-data}]" \
+    --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${name}-graphdb-data},{Key=DeployTag,Value=${deployment_tag}}]" \
     --query "VolumeId" --output text)
   AVAILABLE_VOLUMES+=("$VOLUME_ID")
 

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -42,7 +42,7 @@ data "cloudinit_config" "graphdb_user_data" {
       ebs_volume_size : var.ebs_volume_size
       ebs_volume_iops : var.ebs_volume_iops
       ebs_volume_throughput : var.ebs_volume_throughput
-      deployment_tag : var.deploy_tag
+      deployment_tag : var.deployment_restriction_tag
       device_name : var.device_name
       ebs_kms_key_arn : var.ebs_key_arn
     })

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -42,6 +42,7 @@ data "cloudinit_config" "graphdb_user_data" {
       ebs_volume_size : var.ebs_volume_size
       ebs_volume_iops : var.ebs_volume_iops
       ebs_volume_throughput : var.ebs_volume_throughput
+      deployment_tag : var.deploy_tag
       device_name : var.device_name
       ebs_kms_key_arn : var.ebs_key_arn
     })

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -1,7 +1,7 @@
 # Common parameters
 variable "deploy_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
-  type = string
+  type        = string
 }
 
 variable "resource_name_prefix" {

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -1,6 +1,6 @@
 # Common parameters
 variable "deploy_tag" {
-  description = "Deployment tag."
+  description = "Deployment tag used to restrict access via IAM policies"
   type = string
 }
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -2,6 +2,7 @@
 variable "deployment_restriction_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
   type        = string
+  default     = "deploymentTag"
 }
 
 variable "resource_name_prefix" {

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -1,5 +1,5 @@
 # Common parameters
-variable "deploy_tag" {
+variable "deployment_restriction_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
   type        = string
 }

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -1,4 +1,8 @@
 # Common parameters
+variable "deploy_tag" {
+  description = "Deployment tag."
+  type = string
+}
 
 variable "resource_name_prefix" {
   description = "Resource name prefix used for tagging and naming AWS resources."

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 # Common configurations
-variable "deploy_tag" {
+variable "deployment_restriction_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
 # Common configurations
+variable "deploy_tag" {
+  description = "Deployment tag."
+  type = string
+}
 
 variable "common_tags" {
   description = "(Optional) Map of common tags for all taggable AWS resources."

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 # Common configurations
 variable "deploy_tag" {
-  description = "Deployment tag."
-  type = string
+  description = "Deployment tag used to restrict access via IAM policies"
+  type        = string
 }
 
 variable "common_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,10 @@
 # Common configurations
+
+
 variable "deployment_restriction_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
   type        = string
+  default     = "deploymentTag"
 }
 
 variable "common_tags" {


### PR DESCRIPTION
Add restrictions on ec2:CreateTags, ec2:CreateVolume and ec2:AttachVolume. Add deploy_tag variable

## Description

Add restrictions on ec2:CreateTags, ec2:CreateVolume and ec2:AttachVolume. Add deploy_tag variable

## Related Issues

[https://ontotext.atlassian.net/browse/GDB-11618](GDB-11618)

## Changes

- Add restrictions on ec2:CreateTags
- Add restrictions on ec2:CreateVolume
- Add restrictions on ec2:AttachVolume. 
- Add deploy_tag variable

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
