### PR TITLE
GDB-11915 Added a toggle for the Availability tests in CloudWatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Added ability to use custom principal for EBS Admin Role and Param Store Admin role via assume_role_principal_arn variable
 * Updated graphdb_instance_ssm policy in iam.tf - added restrictions on ssm:DescribeParameters to only allow usage on graphdb-related resources.
 * Updated graphdb_instance_ssm polict in iam.tf - restricted kms actions to Decrypt only
-* Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users 
+* Changed owner of /etc/prometheus to cwagent:cwagent. Removed rw permissions for /etc/prometheus/prometheus.yaml for other an group users
+* Added a toggle for enabling/disabling the availability tests in CloudWatch
 
 ## 1.3.3
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | monitoring\_route53\_health\_check\_aws\_region | Define the region in which you want the monitoring to be deployed. It is used to define where the Route53 Availability Check will be deployed, since if it is not specified it will deploy the check in us-east-1 and if you deploy in different region it will not find the dimensions. | `string` | `"us-east-1"` | no |
 | monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80` | no |
 | monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443` | no |
+| monitoring\_enable\_availability\_tests | Enable Route 53 availability tests and alarms | `bool` | `true` | no |
 | graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null` | no |
 | graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null` | no |
 | deploy\_logging\_module | Enable or disable logging module | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -222,6 +222,7 @@ module "monitoring" {
   cmk_key_alias                          = var.sns_cmk_key_alias
   parameter_store_kms_key_arn            = local.calculated_parameter_store_kms_key_arn
   cloudwatch_log_group_retention_in_days = var.monitoring_log_group_retention_in_days
+  enable_availability_tests              = var.monitoring_enable_availability_tests
 
   route53_availability_check_region     = var.monitoring_route53_health_check_aws_region
   route53_availability_request_url      = var.graphdb_node_count > 1 ? var.graphdb_external_dns : module.load_balancer.lb_dns_name

--- a/modules/monitoring/availability_tests.tf
+++ b/modules/monitoring/availability_tests.tf
@@ -3,22 +3,27 @@
 # SNS Topic for the Route53 Health Check Alarm
 
 resource "aws_sns_topic" "graphdb_route53_sns_topic" {
+  count = var.enable_availability_tests ? 1 : 0
+
   provider          = aws.useast1
   name              = "${var.resource_name_prefix}-route53-sns-notifications"
   kms_master_key_id = var.sns_external_kms_key != "" ? var.sns_external_kms_key : (var.enable_sns_kms_key ? aws_kms_key.sns_cmk[0].arn : var.sns_default_kms_key)
 }
 
 resource "aws_sns_topic_subscription" "graphdb_route53_sns_topic_subscription" {
+  count = var.enable_availability_tests ? 1 : 0
+
   provider               = aws.useast1
-  topic_arn              = aws_sns_topic.graphdb_route53_sns_topic.id
+  topic_arn              = aws_sns_topic.graphdb_route53_sns_topic[0].id
   protocol               = var.sns_protocol
   endpoint               = var.sns_topic_endpoint
   endpoint_auto_confirms = var.sns_endpoint_auto_confirms
 }
 
 # Route 53 Availability Check
-
 resource "aws_route53_health_check" "graphdb_availability_check" {
+  count = var.enable_availability_tests ? 1 : 0
+
   provider          = aws.useast1
   failure_threshold = var.route53_availability_timeout
   fqdn              = var.route53_availability_request_url != "" ? var.route53_availability_request_url : var.lb_dns_name
@@ -31,8 +36,9 @@ resource "aws_route53_health_check" "graphdb_availability_check" {
 }
 
 # Availability Alert
-
 resource "aws_cloudwatch_metric_alarm" "graphdb_availability_alert" {
+  count = var.enable_availability_tests ? 1 : 0
+
   provider            = aws.useast1
   alarm_name          = "al-${var.resource_name_prefix}-availability"
   alarm_description   = "Alarm will trigger if availability goes beneath 100"
@@ -44,9 +50,9 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_availability_alert" {
   statistic           = "Average"
   threshold           = "100"
   actions_enabled     = var.cloudwatch_alarms_actions_enabled
-  alarm_actions       = [aws_sns_topic.graphdb_route53_sns_topic.arn]
+  alarm_actions       = [aws_sns_topic.graphdb_route53_sns_topic[0].arn]
 
   dimensions = {
-    HealthCheckId = aws_route53_health_check.graphdb_availability_check.id
+    HealthCheckId = aws_route53_health_check.graphdb_availability_check[0].id
   }
 }

--- a/modules/monitoring/graphdb_dashboard_no_availability.json
+++ b/modules/monitoring/graphdb_dashboard_no_availability.json
@@ -1,0 +1,202 @@
+{
+  "widgets": [
+      {
+          "height": 6,
+          "width": 6,
+          "y": 0,
+          "x": 6,
+          "type": "metric",
+          "properties": {
+              "metrics": [
+                  [ { "expression": "SELECT MAX(CPUUtilization) FROM \"AWS/EC2\" GROUP BY AutoScalingGroupName", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+              ],
+              "region": "${aws_region}",
+              "stacked": false,
+              "view": "timeSeries",
+              "period": 300,
+              "stat": "Average",
+              "yAxis": {
+                  "left": {
+                      "max": 100,
+                      "label": "Percent",
+                      "showUnits": false
+                  },
+                  "right": {
+                      "label": "",
+                      "showUnits": false
+                  }
+              },
+              "title": "CPU utilization for the Auto Scaling Group"
+          }
+      },
+      {
+        "height": 6,
+        "width": 6,
+        "y": 0,
+        "x": 12,
+        "type": "metric",
+        "properties": {
+            "metrics": [
+                [ { "expression": "SELECT MAX(mem_used_percent) FROM \"CWAgent\" GROUP BY AutoScalingGroupName", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+            ],
+            "region": "${aws_region}",
+            "stacked": false,
+            "view": "timeSeries",
+            "period": 300,
+            "stat": "Average",
+            "yAxis": {
+                "left": {
+                    "max": 100,
+                    "label": "Percent",
+                    "showUnits": false
+                },
+                "right": {
+                    "label": "",
+                    "showUnits": false
+                }
+            },
+            "title": "GraphDB Memory Used % for the Auto Scaling Group"
+        }
+    },
+      {
+          "height": 6,
+          "width": 6,
+          "y": 6,
+          "x": 6,
+          "type": "metric",
+          "properties": {
+              "metrics": [
+                  [ { "expression": "SELECT AVG(graphdb_data_dir_free) FROM \"${resource_name_prefix}\" GROUP BY host", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+              ],
+              "region": "${aws_region}",
+              "stacked": false,
+              "view": "timeSeries",
+              "period": 300,
+              "stat": "Average",
+              "yAxis": {
+                  "left": {
+                      "label": "Gigabytes",
+                      "showUnits": false
+                  },
+                  "right": {
+                      "label": "",
+                      "showUnits": false
+                  }
+              },
+              "title": "GraphDB Data Dir Free per instance"
+          }
+      },
+      {
+          "height": 6,
+          "width": 6,
+          "y": 6,
+          "x": 0,
+          "type": "metric",
+          "properties": {
+              "metrics": [
+                  [ { "expression": "SELECT AVG(graphdb_data_dir_used) FROM \"${resource_name_prefix}\" GROUP BY host", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+              ],
+              "region": "${aws_region}",
+              "stacked": false,
+              "view": "timeSeries",
+              "period": 300,
+              "stat": "Average",
+              "yAxis": {
+                  "left": {
+                      "label": "Gigabytes",
+                      "showUnits": false
+                  },
+                  "right": {
+                      "label": "",
+                      "showUnits": false
+                  }
+              },
+              "title": "GraphDB Data Dir Used per instance"
+          }
+      },
+      {
+          "height": 6,
+          "width": 6,
+          "y": 0,
+          "x": 18,
+          "type": "metric",
+          "properties": {
+              "metrics": [
+                  [ { "expression": "SELECT COUNT(graphdb_failure_recoveries_count) FROM \"${resource_name_prefix}\"", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+              ],
+              "region": "${aws_region}",
+              "stacked": false,
+              "view": "timeSeries",
+              "period": 300,
+              "stat": "Average",
+              "yAxis": {
+                  "left": {
+                      "label": "Count",
+                      "showUnits": false
+                  },
+                  "right": {
+                      "label": "",
+                      "showUnits": false
+                  }
+              },
+              "title": "GraphDB Failure Recoveries"
+          }
+      },
+      {
+          "height": 6,
+          "width": 6,
+          "y": 6,
+          "x": 18,
+          "type": "metric",
+          "properties": {
+              "metrics": [
+                  [ { "expression": "SELECT MAX(graphdb_nodes_disconnected) FROM \"${resource_name_prefix}\"", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+              ],
+              "region": "${aws_region}",
+              "stacked": false,
+              "view": "timeSeries",
+              "period": 300,
+              "stat": "Average",
+              "yAxis": {
+                  "left": {
+                      "label": "Count",
+                      "showUnits": false
+                  },
+                  "right": {
+                      "label": "",
+                      "showUnits": false
+                  }
+              },
+              "title": "GraphDB nodes disconnected"
+          }
+      },
+      {
+        "height": 6,
+        "width": 6,
+        "y": 6,
+        "x": 12,
+        "type": "metric",
+        "properties": {
+            "metrics": [
+                [ { "expression": "SELECT MAX(graphdb_nodes_out_of_sync) FROM \"${resource_name_prefix}\"", "label": "Query1", "id": "q1", "region": "${aws_region}" } ]
+            ],
+            "region": "${aws_region}",
+            "stacked": false,
+            "view": "timeSeries",
+            "period": 300,
+            "stat": "Average",
+            "yAxis": {
+                "left": {
+                    "label": "Count",
+                    "showUnits": false
+                },
+                "right": {
+                    "label": "",
+                    "showUnits": false
+                }
+            },
+            "title": "GraphDB nodes out of sync"
+        }
+    }
+  ]
+}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -23,12 +23,14 @@ resource "aws_ssm_parameter" "graphdb_cloudwatch_agent_config" {
 
 resource "aws_cloudwatch_dashboard" "graphdb_dashboard" {
   dashboard_name = var.resource_name_prefix
-  dashboard_body = templatefile("${path.module}/graphdb_dashboard.json", {
-    health_check_id                   = aws_route53_health_check.graphdb_availability_check.id
+  dashboard_body = var.enable_availability_tests ? templatefile("${path.module}/graphdb_dashboard.json", {
+    health_check_id                   = aws_route53_health_check.graphdb_availability_check[0].id
     resource_name_prefix              = var.resource_name_prefix
     aws_region                        = var.aws_region
     route53_availability_check_region = var.route53_availability_check_region
+    }) : templatefile("${path.module}/graphdb_dashboard_no_availability.json", {
+    resource_name_prefix = var.resource_name_prefix
+    aws_region           = var.aws_region
   })
 }
-
 

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -202,3 +202,8 @@ variable "lb_dns_name" {
   description = "Define the LB DNS name"
   type        = string
 }
+
+variable "enable_availability_tests" {
+  description = "Enable Route 53 availability tests and alarms"
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -414,6 +414,12 @@ variable "monitoring_route53_availability_https_port" {
   default     = 443
 }
 
+variable "monitoring_enable_availability_tests" {
+  description = "Enable Route 53 availability tests and alarms"
+  type        = bool
+  default     = true
+}
+
 # GraphDB overrides
 
 variable "graphdb_properties_path" {


### PR DESCRIPTION
## Description

Added a toggle for the Availability tests in CloudWatch

## Related Issues

GDB-11915 

## Changes
* Added a toggle for the Availability tests in CloudWatch
* Introduced a new variable `monitoring_enable_availability_tests` 
* Added a dashboard without the availability monitoring widget

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
