### PR TITLE
GDB-11621 Run cronjob as root, to make sure that backup rotation works correctly.

### DIFF
--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -82,7 +82,7 @@ GDB_PROPERTIES=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${regi
 extra_graphdb_java_options="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_java_options" --with-decryption 2>/dev/null | jq -r .Parameter.Value || /bin/true )"
 if [[ -n $extra_graphdb_java_options  ]]; then
   if grep GDB_JAVA_OPTS /etc/graphdb/graphdb.env &>/dev/null; then
-    sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
+    sed -ie "s|GDB_JAVA_OPTS=\"\(.*\)\"|GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"|g" /etc/graphdb/graphdb.env
   else
     echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env
   fi

--- a/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
+++ b/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
@@ -23,7 +23,6 @@ if [ ${deploy_backup} == "true" ]; then
   # Initialize the log file so that we are safe from potential attacks
   [[ -f /var/opt/graphdb/node/graphdb_backup.log ]] && rm /var/opt/graphdb/node/graphdb_backup.log
   touch /var/opt/graphdb/node/graphdb_backup.log
-  # We should already be root but let's make sure
   chown gdb-backup:gdb-backup /var/opt/graphdb/node/graphdb_backup.log
   chmod og-rw /var/opt/graphdb/node/graphdb_backup.log
   cat <<-EOF >/usr/bin/graphdb_backup


### PR DESCRIPTION
## Description

Run cronjob as root user to make sure that the backup rotation works correctly (without exposing aws cli to low-priv users)

## Related Issues

[GDB-11621](https://graphwise.atlassian.net/browse/GDB-11621)

## Changes

* Run cronjob as root
* Make sure backup log file is initialized correctly during provision


## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11621]: https://graphwise.atlassian.net/browse/GDB-11621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ