### PR TITLE
Features for 1.5.0

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:2A5UZnERIQPA9PMmbdfgFNqbYjUxk10J7W6d5QcTCM4=",
     "h1:IYq3by7O/eJuXzJwOF920z2nZEkw08PkDFdw2xkyhrs=",
+    "h1:z2CG1IX+2d6pvDVUNlTeb2/UD6CTSU4M1ntSmQCiWUM=",
     "zh:017f237466875c919330b9e214fb33af14fffbff830d3755e8976d8fa3c963c2",
     "zh:0776d1e60aa93c85ecbb01144aed2789c8e180bb0f1c811a0aba17ca7247b26c",
     "zh:0dfa5c6cfb3724494fdc73f7d042515e88a20da8968959f48b3ec0b937bd8c8f",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.3.5"
   hashes = [
+    "h1:HCoabXm6NQwCivl1q24+l9VUufc2mFqNeulsQBA9iFg=",
     "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
     "h1:wbw64JlCobcQCAdlzHpxksQ1GabewTW1yxnACBVZh4A=",
     "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
     "h1:N2IQabOiZC5eCEGrfgVS6ChVmRDh1ENtfHgGjnV4QQQ=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 1.5.0
+* Added ability to provide additional ARNs for IAM Policies
+* Added ability to get dynamic http protocol for gdb_conf_overrides based on the lb_certificate_arn
+* Removed the `asg_enable_instance_refresh` property and the instance auto-refresh functionality.
+* Fixed issue where the cluster was not formed when scaling from 1 node to 3 or more nodes.
+* Updated backup script to use the new multipart endpoint
+* Updated backup script to permanently delete old backups
+
 ## 1.4.1
 
 * Update default GraphDB version to [10.8.5](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-5)

--- a/main.tf
+++ b/main.tf
@@ -245,6 +245,7 @@ module "graphdb" {
   aws_region                 = data.aws_region.current.name
   aws_subscription_id        = data.aws_caller_identity.current.account_id
   assume_role_principal_arn  = var.assume_role_principal_arn
+  additional_policy_arns     = var.graphdb_additional_policy_arns
 
   # Networking
 
@@ -337,8 +338,6 @@ module "graphdb" {
   backup_enable_replication  = var.backup_enable_bucket_replication
 
   # ASG instance deployment options
-  asg_enable_instance_refresh               = var.asg_enable_instance_refresh
-  asg_instance_refresh_checkpoint_delay     = var.asg_instance_refresh_checkpoint_delay
   graphdb_enable_userdata_scripts_on_reboot = var.graphdb_enable_userdata_scripts_on_reboot
   user_supplied_scripts                     = var.graphdb_user_supplied_scripts
   user_supplied_templates                   = var.graphdb_user_supplied_templates

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -81,7 +81,9 @@ data "aws_iam_policy_document" "backup_s3_crud" {
       "s3:PutObject",
       "s3:GetAccelerateConfiguration",
       "s3:ListMultipartUploadParts",
-      "s3:AbortMultipartUpload"
+      "s3:AbortMultipartUpload",
+      "s3:ListBucketVersions",
+      "s3:DeleteObjectVersion"
     ]
     resources = [
       # the exact ARN is needed for the list bucket action, star for put,get,delete

--- a/modules/graphdb/iam.tf
+++ b/modules/graphdb/iam.tf
@@ -520,3 +520,9 @@ resource "aws_iam_role_policy" "param_store_key_admin_role_permissions" {
   role   = aws_iam_role.param_store_key_admin_role.name
   policy = data.aws_iam_policy_document.param_store_key_admin_role_permissions.json
 }
+
+resource "aws_iam_role_policy_attachment" "additional_policies" {
+  for_each   = toset(var.additional_policy_arns)
+  role       = aws_iam_role.graphdb_iam_role.id
+  policy_arn = each.value
+}

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -97,24 +97,6 @@ resource "aws_autoscaling_group" "graphdb_auto_scaling_group" {
     version = aws_launch_template.graphdb.latest_version
   }
 
-  dynamic "instance_refresh" {
-    for_each = var.asg_enable_instance_refresh ? [1] : []
-    content {
-      strategy = "Rolling"
-
-      preferences {
-        min_healthy_percentage = var.asg_instance_refresh_min_healthy_percentage
-        instance_warmup        = var.asg_instance_refresh_instance_warmup
-        skip_matching          = var.asg_instance_refresh_skip_matching
-        checkpoint_delay       = var.asg_instance_refresh_checkpoint_delay
-        checkpoint_percentages = [
-          for i in range(var.graphdb_node_count) :
-          floor((i + 1) * 100 / var.graphdb_node_count)
-        ]
-      }
-    }
-  }
-
   tag {
     key                 = "DeployTag"
     value               = var.deployment_restriction_tag

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -52,8 +52,8 @@ EOF
   cat << EOF > /etc/graphdb-cluster-proxy/graphdb.properties
 graphdb.auth.token.secret=$GRAPHDB_CLUSTER_TOKEN
 graphdb.connector.port=7200
-graphdb.external-url=http://$${LB_DNS_RECORD}
-graphdb.vhosts=http://$${LB_DNS_RECORD},http://$${NODE_DNS_RECORD}:7200
+graphdb.external-url=$${PROTOCOL}://$${LB_DNS_RECORD}
+graphdb.vhosts=$${PROTOCOL}://$${LB_DNS_RECORD},http://$${NODE_DNS_RECORD}:7200
 graphdb.rpc.address=$${NODE_DNS_RECORD}:7300
 graphdb.proxy.hosts=$${NODE_DNS_RECORD}:7301
 EOF

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -233,34 +233,6 @@ variable "graphdb_enable_userdata_scripts_on_reboot" {
   type        = bool
 }
 
-variable "asg_enable_instance_refresh" {
-  description = "Enables instance refresh for the GraphDB Auto scaling group"
-  type        = bool
-}
-
-variable "asg_instance_refresh_min_healthy_percentage" {
-  description = "Specifies the lower limit on the number of instances that must be in the InService state with a healthy status during an instance replacement activity."
-  type        = number
-  default     = 66
-}
-
-variable "asg_instance_refresh_instance_warmup" {
-  description = "Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period."
-  type        = number
-  default     = 0
-}
-
-variable "asg_instance_refresh_skip_matching" {
-  description = " Replace instances that already have your desired configuration."
-  type        = bool
-  default     = false
-}
-
-variable "asg_instance_refresh_checkpoint_delay" {
-  description = "Number of seconds to wait after a checkpoint."
-  type        = number
-}
-
 variable "lb_enable_private_access" {
   description = "Enable or disable the private access via PrivateLink to the GraphDB Cluster"
   type        = bool
@@ -441,4 +413,10 @@ variable "user_supplied_templates" {
     variables = map(any)
   }))
   default = []
+}
+
+variable "additional_policy_arns" {
+  description = "List of additional IAM policy ARNs to attach to the instance IAM role"
+  type        = list(string)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,5 @@
 # Common configurations
 
-
 variable "deployment_restriction_tag" {
   description = "Deployment tag used to restrict access via IAM policies"
   type        = string
@@ -57,7 +56,14 @@ variable "assume_role_principal_arn" {
   default     = null
 }
 
+variable "graphdb_additional_policy_arns" {
+  description = "List of additional IAM policy ARNs to attach to the instance IAM role"
+  type        = list(string)
+  default     = []
+}
+
 # Backup configurations
+
 variable "deploy_backup" {
   description = "Deploy backup module"
   type        = bool
@@ -529,18 +535,6 @@ variable "bucket_replication_destination_region" {
 
 # ASG instance deployment options
 
-variable "asg_enable_instance_refresh" {
-  description = "Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch_configuration, launch_template, mixed_instances_policy"
-  type        = bool
-  default     = false
-}
-
-variable "asg_instance_refresh_checkpoint_delay" {
-  description = "Number of seconds to wait after a checkpoint."
-  type        = number
-  default     = 3600
-}
-
 variable "graphdb_enable_userdata_scripts_on_reboot" {
   description = "(Experimental) Modifies cloud-config to always run user data scripts on EC2 boot"
   type        = bool
@@ -765,6 +759,7 @@ variable "create_ebs_kms_key" {
   type        = bool
   default     = false
 }
+
 # SNS Encryption
 
 variable "create_sns_kms_key" {


### PR DESCRIPTION
## Description

- Added ability to provide additional ARNs for IAM Policies
- Added ability to get dynamic http protocol for gdb_conf_overrides based on the lb_certificate_arn
- Removed the `asg_enable_instance_refresh` property and the instance auto-refresh functionality.
- Fixed issue where the cluster was not formed when scaling from 1 node to 3 or more nodes.
- Updated backup script to use the new multipart endpoint
- Updated backup script to permanently delete old backups

## Related Issues

[GDB-12038]
[GDB-12104]
[GDB-12101]
[GDB-12055]
[GDB-12092]

## Changes

- Added ability to provide additional ARNs for IAM Policies
- Added ability to get dynamic http protocol for gdb_conf_overrides based on the lb_certificate_arn
- Removed the `asg_enable_instance_refresh` property and the instance auto-refresh functionality.
- Fixed issue where the cluster was not formed when scaling from 1 node to 3 or more nodes.
- Updated backup script to use the new multipart endpoint
- Updated backup script to permanently delete old backups

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.



[GDB-12038]: https://graphwise.atlassian.net/browse/GDB-12038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12104]: https://graphwise.atlassian.net/browse/GDB-12104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12101]: https://graphwise.atlassian.net/browse/GDB-12101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12055]: https://graphwise.atlassian.net/browse/GDB-12055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12092]: https://graphwise.atlassian.net/browse/GDB-12092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ