### PR TITLE
GDB-12101 Updated the logic to properly form a cluster when scaling from 1 to 3 or more nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # GraphDB AWS Terraform Module Changelog
 
 ## 1.5.0
-* Added ability to provide additiona ARNs for IAM Policies
+* Added ability to provide additional ARNs for IAM Policies
 * Added ability to get dynamic http protocol for gdb_conf_overrides based on the lb_certificate_arn
+* Removed the `asg_enable_instance_refresh` property and the instance auto-refresh functionality.
+* Fixed issue where the cluster was not formed when scaling from 1 node to 3 or more nodes.
 * Updated backup script to use the new multipart endpoint
 
 ## 1.4.1

--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ To do this, set `graphdb_node_count` to `1`, and the rest will be handled automa
 is not fully automated. While the Terraform module will allow you to scale up and create 3 instances,
 the cluster will not be formed unless you terminate the initial node.
 
+**Note:** Make sure that the new instances are running before terminating the initial node.
+
 **Please note that this operation is disruptive, and there is a risk that things may not go as expected.**
 
 ## Updating configurations on an active deployment
@@ -626,29 +628,11 @@ Support for this will be introduced in the future.
 
 ### Upgrading GraphDB Version
 
-To automatically update the GraphDB version with `terraform apply`, you could set `asg_enable_instance_refresh` to `true`
-in your `tfvars` file. This configuration will enable [instance refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/instance-refresh-overview.html)
-for the ASG and will replace your already running instances with new ones, one at a time.
+Updating the graphdb version is performed by changing the value of `graphdb_version` property and executing `terraform apply`.
 
-By default, the instance refresh process waits for one hour before updating the next instance.
-This delay allows GraphDB time to sync with other nodes.
-You can adjust this delay by changing the `asg_instance_refresh_checkpoint_delay` value.
-If there are many writes to the cluster, consider increasing this delay.
-
-Note that any changes to GraphDB configurations will be applied during the instance refresh process,
-except for the `graphdb_admin_password`.
-Support for updating the admin password will be introduced in a future release.
-
-### ⚠️ **WARNING**
-Enabling `asg_enable_instance_refresh` while scaling out the GraphDB cluster may lead to data replication issues or broken cluster configuration.
-Existing instances could still undergo the refresh process, might change their original Availability zone
-and new nodes might fail to join the cluster due to the instance refresh, depending on the data size.
-
-**We strongly recommend disabling `asg_enable_instance_refresh` when scaling up the cluster.**
-
-To work around this issue, you can manually set "Scale-in protection" on the existing nodes, scale out the cluster,
-and then remove the "Scale-in protection".
-However, any configuration changes will not be applied to the old instances, which could cause them to drift apart.
+Note that the EC2 instances won't be automatically updated to the latest model, and they need to be recreated.
+Make sure the instances are recreated one by one, allowing them time to rejoin the cluster, to avoid downtime and
+unexpected behavior.
 
 ## Local Development
 

--- a/main.tf
+++ b/main.tf
@@ -338,8 +338,6 @@ module "graphdb" {
   backup_enable_replication  = var.backup_enable_bucket_replication
 
   # ASG instance deployment options
-  asg_enable_instance_refresh               = var.asg_enable_instance_refresh
-  asg_instance_refresh_checkpoint_delay     = var.asg_instance_refresh_checkpoint_delay
   graphdb_enable_userdata_scripts_on_reboot = var.graphdb_enable_userdata_scripts_on_reboot
   user_supplied_scripts                     = var.graphdb_user_supplied_scripts
   user_supplied_templates                   = var.graphdb_user_supplied_templates

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -97,24 +97,6 @@ resource "aws_autoscaling_group" "graphdb_auto_scaling_group" {
     version = aws_launch_template.graphdb.latest_version
   }
 
-  dynamic "instance_refresh" {
-    for_each = var.asg_enable_instance_refresh ? [1] : []
-    content {
-      strategy = "Rolling"
-
-      preferences {
-        min_healthy_percentage = var.asg_instance_refresh_min_healthy_percentage
-        instance_warmup        = var.asg_instance_refresh_instance_warmup
-        skip_matching          = var.asg_instance_refresh_skip_matching
-        checkpoint_delay       = var.asg_instance_refresh_checkpoint_delay
-        checkpoint_percentages = [
-          for i in range(var.graphdb_node_count) :
-          floor((i + 1) * 100 / var.graphdb_node_count)
-        ]
-      }
-    }
-  }
-
   tag {
     key                 = "DeployTag"
     value               = var.deployment_restriction_tag

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -233,34 +233,6 @@ variable "graphdb_enable_userdata_scripts_on_reboot" {
   type        = bool
 }
 
-variable "asg_enable_instance_refresh" {
-  description = "Enables instance refresh for the GraphDB Auto scaling group"
-  type        = bool
-}
-
-variable "asg_instance_refresh_min_healthy_percentage" {
-  description = "Specifies the lower limit on the number of instances that must be in the InService state with a healthy status during an instance replacement activity."
-  type        = number
-  default     = 66
-}
-
-variable "asg_instance_refresh_instance_warmup" {
-  description = "Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period."
-  type        = number
-  default     = 0
-}
-
-variable "asg_instance_refresh_skip_matching" {
-  description = " Replace instances that already have your desired configuration."
-  type        = bool
-  default     = false
-}
-
-variable "asg_instance_refresh_checkpoint_delay" {
-  description = "Number of seconds to wait after a checkpoint."
-  type        = number
-}
-
 variable "lb_enable_private_access" {
   description = "Enable or disable the private access via PrivateLink to the GraphDB Cluster"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -535,18 +535,6 @@ variable "bucket_replication_destination_region" {
 
 # ASG instance deployment options
 
-variable "asg_enable_instance_refresh" {
-  description = "Enables instance refresh for the GraphDB Auto scaling group. A refresh is started when any of the following Auto Scaling Group properties change: launch_configuration, launch_template, mixed_instances_policy"
-  type        = bool
-  default     = false
-}
-
-variable "asg_instance_refresh_checkpoint_delay" {
-  description = "Number of seconds to wait after a checkpoint."
-  type        = number
-  default     = 3600
-}
-
 variable "graphdb_enable_userdata_scripts_on_reboot" {
   description = "(Experimental) Modifies cloud-config to always run user data scripts on EC2 boot"
   type        = bool


### PR DESCRIPTION


## Description
GDB-12101 Updated the logic to properly form a cluster when scaling from 1 to 3 or more nodes.
Removed the `asg_enable_instance_refresh` functionality. Updated the CHANGELOG.md

## Related Issues

GDB-12101

## Changes

Removed the  `asg_enable_instance_refresh` functionality. 
Changed the logic of forming the cluster when scaling from 1 to 3 or more nodes to correctly handle the cluster formation. 

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
