### PR TITLE
Update backup script to use multipart endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0
 * Added ability to provide additiona ARNs for IAM Policies
 * Added ability to get dynamic http protocol for gdb_conf_overrides based on the lb_certificate_arn
+* Updated backup script to use the new multipart endpoint
 
 ## 1.4.1
 


### PR DESCRIPTION
## Description

Version 10.8.0 unified the local and cloud backup and restore endpoints to use the same JSON structure for the request payload.
The endpoint was also updated to use a multipart content type and the old JSON endpoint was deprecated.

## Related Issues

GDB-12092

## Changes

* update backup script to use multipart endpoint as described [here](https://graphdb.ontotext.com/documentation/10.8/backup-and-restore.html#creating-a-cloud-backup)

## Screenshots (if applicable)

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
