### PR TITLE
[GDB-12318] Fix permissions issue with CloudWatch Alarms and change SNS CMK key alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Added option to choose between Application Load Balancer and Network Load Balancer
 * Resolved an issue in the additional user data script where incorrect handling of AWS CLI permissions (chmod)
   that caused cloud-init to fail during instance initialization.
+* Fixed SNS Key Access Policy so Cloudwatch Service can publish to the SNS topic [Cloudwatch Alarms via SNS](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns)
+* Removed monitoring_actions_enabled because it's enabled by default in the provider if action is specified.
+* Introduced new variables app_name and environment name, so if you deploy several deployments in one account, to be able to deploy different CMK keys.
+* Moved the CMK Alias generation in a local variable so it can be dynamically generated.
 
 ## 2.0.1
 * Updated GraphDB default version to [11.0.1](https://graphdb.ontotext.com/documentation/11.0/release-notes.html#graphdb-11-0-1)

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ To enable deployment of the monitoring module, you need to enable the following 
 deploy_monitoring = true
 ```
 
+**Note**: In order for the Cloudwatch Alarms to be able to publish alarms in SNS you should use [CMK key](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns).
+
 **Providing a TLS certificate**
 
 ```hcl
@@ -498,6 +500,16 @@ or you can use the current AWS account by leaving this parameter empty.
 
 ```hcl
 s3_kms_key_admin_arn = "arn:aws:iam::123456789012:role/KeyAdminRole"
+```
+
+##### SNS CMK Key
+You can enable the creation of SNS CMK Key which you will need if you want to publish Cloudwatch Alarms to SNS Topic. Use the following variables to enable it:
+
+```hcl
+create_sns_kms_key            = true
+sns_key_admin_arn             = "arn:aws:iam::123456789012:user/john.doh@example.com"
+app_name                      = "example_app"
+environment_name              = "env_name"
 ```
 
 #### Replication

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | deployment\_restriction\_tag | Deployment tag used to restrict access via IAM policies | `string` | `"deploymentTag"` | no |
+| environment\_name | Environment name used to generate the environment | `string` | `""` | no |
+| app\_name | Application name used to generate the environment | `string` | `""` | no |
 | common\_tags | (Optional) Map of common tags for all taggable AWS resources. | `map(string)` | `{}` | no |
 | resource\_name\_prefix | Resource name prefix used for tagging and naming AWS resources | `string` | n/a | yes |
 | aws\_region | AWS region to deploy resources into | `string` | n/a | yes |
@@ -152,7 +154,6 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | graphdb\_external\_dns | External domain name where GraphDB will be accessed | `string` | `""` | no |
 | deploy\_monitoring | Enable or disable toggle for monitoring | `bool` | `false` | no |
 | monitoring\_route53\_measure\_latency | Enable or disable route53 function to measure latency | `bool` | `false` | no |
-| monitoring\_actions\_enabled | Enable or disable actions on alarms | `bool` | `false` | no |
 | monitoring\_sns\_topic\_endpoint | Define an SNS endpoint which will be receiving the alerts via email | `string` | `null` | no |
 | monitoring\_sns\_protocol | Define an SNS protocol that you will use to receive alerts. Possible options are: Email, Email-JSON, HTTP, HTTPS. | `string` | `"email"` | no |
 | monitoring\_enable\_detailed\_instance\_monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -44,11 +44,14 @@ locals {
     )
   ) : var.sns_default_kms_key
 
+  cmk_key_alias = var.deploy_monitoring ? (
+    var.app_name != "" && var.environment_name != ""
+    ? "alias/${var.app_name}-${var.environment_name}-graphdb-sns-cmk-alias"
+  : var.sns_cmk_key_alias) : null
 
   # TLS & Protocol
   lb_tls_enabled      = var.lb_tls_certificate_arn != "" ? true : false
   calculated_protocol = local.lb_tls_enabled ? "https" : "http"
-
 
   # Subnet CIDR lists
   effective_private_subnet_cidrs = var.graphdb_node_count == 1 ? [var.vpc_private_subnet_cidrs[0]] : var.vpc_private_subnet_cidrs
@@ -263,7 +266,6 @@ module "monitoring" {
   resource_name_prefix = var.resource_name_prefix
   aws_region           = var.aws_region
 
-  cloudwatch_alarms_actions_enabled      = var.monitoring_actions_enabled
   sns_topic_endpoint                     = var.deploy_monitoring ? var.monitoring_sns_topic_endpoint : null
   sns_endpoint_auto_confirms             = var.monitoring_endpoint_auto_confirms
   sns_protocol                           = var.monitoring_sns_protocol
@@ -276,7 +278,7 @@ module "monitoring" {
   key_enabled                            = var.sns_key_enabled
   key_spec                               = var.sns_key_spec
   sns_default_kms_key                    = var.sns_default_kms_key
-  cmk_key_alias                          = var.sns_cmk_key_alias
+  cmk_key_alias                          = local.cmk_key_alias
   parameter_store_kms_key_arn            = local.calculated_parameter_store_kms_key_arn
   cloudwatch_log_group_retention_in_days = var.monitoring_log_group_retention_in_days
   enable_availability_tests              = var.monitoring_enable_availability_tests

--- a/modules/monitoring/alarms.tf
+++ b/modules/monitoring/alarms.tf
@@ -141,7 +141,6 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_cpu_utilization" {
   period              = var.cloudwatch_period
   statistic           = "Maximum"
   threshold           = 80
-  actions_enabled     = var.cloudwatch_alarms_actions_enabled
   alarm_actions       = [aws_sns_topic.graphdb_sns_topic.arn]
 
   metric_name = "CPUUtilization"

--- a/modules/monitoring/availability_tests.tf
+++ b/modules/monitoring/availability_tests.tf
@@ -49,7 +49,6 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_availability_alert" {
   period              = var.cloudwatch_period
   statistic           = "Average"
   threshold           = "100"
-  actions_enabled     = var.cloudwatch_alarms_actions_enabled
   alarm_actions       = [aws_sns_topic.graphdb_route53_sns_topic[0].arn]
 
   dimensions = {

--- a/modules/monitoring/cmk.tf
+++ b/modules/monitoring/cmk.tf
@@ -95,7 +95,8 @@ resource "aws_kms_key_policy" "sns_cmk_policy" {
           "Service" : [
             "sns.amazonaws.com",
             "ec2.amazonaws.com",
-            "ssm.amazonaws.com"
+            "ssm.amazonaws.com",
+            "cloudwatch.amazonaws.com"
           ]
         },
         "Action" : [

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -19,11 +19,6 @@ variable "route53_availability_request_url" {
   type        = string
 }
 
-variable "cloudwatch_alarms_actions_enabled" {
-  description = "Enable or disable actions on alarms"
-  type        = bool
-}
-
 variable "route53_availability_frequency" {
   description = "Interval in seconds between tests. Valid options are 5-30. Default is 30."
   type        = number

--- a/provider.tf
+++ b/provider.tf
@@ -28,6 +28,8 @@ provider "aws" {
       {
         Release_Name = var.resource_name_prefix
         Name         = "${var.resource_name_prefix}"
+        Environment  = var.environment_name
+        App_Name     = var.app_name
       },
       var.common_tags
     )

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,18 @@ variable "deployment_restriction_tag" {
   default     = "deploymentTag"
 }
 
+variable "environment_name" {
+  description = "Environment name used to generate the environment"
+  type        = string
+  default     = ""
+}
+
+variable "app_name" {
+  description = "Application name used to generate the environment"
+  type        = string
+  default     = ""
+}
+
 variable "common_tags" {
   description = "(Optional) Map of common tags for all taggable AWS resources."
   type        = map(string)
@@ -398,12 +410,6 @@ variable "deploy_monitoring" {
 
 variable "monitoring_route53_measure_latency" {
   description = "Enable or disable route53 function to measure latency"
-  type        = bool
-  default     = false
-}
-
-variable "monitoring_actions_enabled" {
-  description = "Enable or disable actions on alarms"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description

* Fixed CMK Key Access Policy so Cloudwatch Service can publish to the SNS topic [Cloudwatch Alarms via SNS](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns)
* Removed monitoring_actions_enabled because it's enabled by default in the provider if action is specified.
* Introduced new variables app_name and environment name, so if you deploy several deployments in one account, to be able to deploy different CMK keys.
* Moved the CMK Alias generation in a local variable so it can be dynamically generated.

## Related Issues

[GDB-12318]

## Changes

* Fixed CMK Key Access Policy so Cloudwatch Service can publish to the SNS topic [Cloudwatch Alarms via SNS](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns)
* Removed monitoring_actions_enabled because it's enabled by default in the provider if action is specified.
* Introduced new variables app_name and environment name, so if you deploy several deployments in one account, to be able to deploy different CMK keys.
* Moved the CMK Alias generation in a local variable so it can be dynamically generated.

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
