### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for deriving KMS key administrators from an IAM group, making it easier to manage multi-user access.
 * Introduced new local.admin_user_arns variable to dynamically fetch IAM user ARNs from a group.
 * Improved logic for selecting KMS key principals using conditional preference
+* Added flag enable_asg_wait to be able to disable the function during tests
 
 ## 2.1.0
 * Added ability to use existing Load Balancer for more info check the Existing Load Balancer section in the README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # GraphDB AWS Terraform Module Changelog
 
 ## 2.2.0
+* Added variables to change CPU Utilization and Memory utilization alarms threshold
 * Added support for deriving KMS key administrators from an IAM group, making it easier to manage multi-user access.
 * Introduced new local.admin_user_arns variable to dynamically fetch IAM user ARNs from a group.
 * Improved logic for selecting KMS key principals using conditional preference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # GraphDB AWS Terraform Module Changelog
 
 ## 2.2.0
-
+* Added support for deriving KMS key administrators from an IAM group, making it easier to manage multi-user access.
+* Introduced new local.admin_user_arns variable to dynamically fetch IAM user ARNs from a group.
+* Improved logic for selecting KMS key principals using conditional preference
 
 ## 2.1.0
 * Added ability to use existing Load Balancer for more info check the Existing Load Balancer section in the README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 2.2.0
+
+
 ## 2.1.0
 * Added ability to use existing Load Balancer for more info check the Existing Load Balancer section in the README.md
 * Added option to choose between Application Load Balancer and Network Load Balancer

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | graphdb\_user\_supplied\_scripts | A list of paths to user-supplied shell scripts (local files) to be injected as additional parts in the EC2 user\_data. | `list(string)` | `[]` | no |
 | graphdb\_user\_supplied\_rendered\_templates | A list of strings containing pre-rendered shell script content to be added as parts in EC2 user\_data. | `list(string)` | `[]` | no |
 | graphdb\_user\_supplied\_templates | A list of maps where each map contains a 'path' to the template file and a 'variables' map used to render it. | ```list(object({ path = string variables = map(any) }))``` | `[]` | no |
+| enable\_asg\_wait | Whether to enable waiting for ASG node readiness | `string` | `"true"` | no |
 | create\_s3\_kms\_key | Enable creation of KMS key for S3 bucket encryption | `bool` | `false` | no |
 | s3\_kms\_key\_admin\_arn | ARN of the role or user granted administrative access to the S3 KMS key. | `string` | `""` | no |
 | s3\_key\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
@@ -343,6 +344,16 @@ To enable deployment of the monitoring module, you need to enable the following 
 
 ```hcl
 deploy_monitoring = true
+```
+
+**ASG_WAIT**
+
+That will wait for the termination process to finish to continue attaching the existing volume.
+This is a considerably slow, but necessary operation.
+For testing purposes this operation can be skipped by configuring the following variable:
+
+```hcl
+enable_asg_wait = false
 ```
 
 Changing CPU utilization and Memory Utiliziation Alarm threshold (the values are in %):

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | sns\_key\_spec | Specification of the Key. | `string` | `"SYMMETRIC_DEFAULT"` | no |
 | sns\_key\_enabled | Specifies whether the key is enabled. | `bool` | `true` | no |
 | sns\_rotation\_enabled | Specifies whether key rotation is enabled. | `bool` | `true` | no |
+| iam\_admin\_group | Define IAM group that should have access to the KMS keys and other resources | `string` | `""` | no |
 <!-- END_TF_DOCS -->
 
 ## Usage
@@ -512,6 +513,14 @@ sns_key_admin_arn             = "arn:aws:iam::123456789012:user/john.doh@example
 app_name                      = "example_app"
 environment_name              = "env_name"
 ```
+
+If you want to grant all users in a specific IAM group administrative access to the KMS keys, you can configure the module like this:
+
+```hcl
+iam_admin_group = "Your_Iam_Group_Name"
+```
+
+The module will automatically resolve the ARNs of the users in the specified group and use them as KMS key administrators.
 
 #### Replication
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | monitoring\_route53\_availability\_http\_port | Define the HTTP port for the Route53 availability check | `number` | `80` | no |
 | monitoring\_route53\_availability\_https\_port | Define the HTTPS port for the Route53 availability check | `number` | `443` | no |
 | monitoring\_enable\_availability\_tests | Enable Route 53 availability tests and alarms | `bool` | `true` | no |
+| monitoring\_cpu\_utilization\_threshold | Alarm threshold for Cloudwatch CPU Utilization | `number` | `80` | no |
+| monitoring\_memory\_utilization\_threshold | Alarm threshold for GraphDB Memory Utilization | `number` | `80` | no |
 | graphdb\_properties\_path | Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM. | `string` | `null` | no |
 | graphdb\_java\_options | GraphDB options to pass to GraphDB with GRAPHDB\_JAVA\_OPTS environment variable. | `string` | `null` | no |
 | deploy\_logging\_module | Enable or disable logging module | `bool` | `false` | no |
@@ -341,6 +343,13 @@ To enable deployment of the monitoring module, you need to enable the following 
 
 ```hcl
 deploy_monitoring = true
+```
+
+Changing CPU utilization and Memory Utiliziation Alarm threshold (the values are in %):
+
+```hcl
+monitoring_cpu_utilization_threshold = 80
+monitoring_memory_utilization_threshold = 80
 ```
 
 **Note**: In order for the Cloudwatch Alarms to be able to publish alarms in SNS you should use [CMK key](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns).

--- a/main.tf
+++ b/main.tf
@@ -426,6 +426,7 @@ module "graphdb" {
   user_supplied_scripts                     = var.graphdb_user_supplied_scripts
   user_supplied_templates                   = var.graphdb_user_supplied_templates
   user_supplied_rendered_templates          = var.graphdb_user_supplied_rendered_templates
+  enable_asg_wait                           = var.enable_asg_wait
 
   # Parameter Store Encryption
 

--- a/main.tf
+++ b/main.tf
@@ -312,6 +312,10 @@ module "monitoring" {
 
   lb_tls_certificate_arn = var.lb_tls_certificate_arn
   lb_dns_name            = module.load_balancer[0].lb_dns_name != "" ? module.load_balancer[0].lb_dns_name : null
+
+  # Alarms Threshold
+  cloudwatch_cpu_utilization_threshold = var.monitoring_cpu_utilization_threshold
+  graphdb_memory_utilization_threshold = var.monitoring_memory_utilization_threshold
 }
 
 module "graphdb" {

--- a/main.tf
+++ b/main.tf
@@ -2,52 +2,49 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_group" "iam_admin_group" {
+  count      = var.iam_admin_group != "" ? 1 : 0
+  group_name = var.iam_admin_group
+}
+
+data "aws_iam_user" "admin_users" {
+  for_each = var.iam_admin_group != "" && length(data.aws_iam_group.iam_admin_group) > 0 ? {
+  for user in data.aws_iam_group.iam_admin_group[0].users : user.user_name => user } : tomap({})
+
+  user_name = each.value.user_name
+}
+
 locals {
   # KMS Key ARNs
   calculated_parameter_store_kms_key_arn = var.create_parameter_store_kms_key ? (
-    var.parameter_store_external_kms_key != ""
-    ? var.parameter_store_external_kms_key
-    : (
-      module.graphdb.parameter_store_cmk_arn != ""
-      ? module.graphdb.parameter_store_cmk_arn
-      : var.parameter_store_default_key
-    )
+    var.parameter_store_external_kms_key != "" ? var.parameter_store_external_kms_key :
+    module.graphdb.parameter_store_cmk_arn != "" ? module.graphdb.parameter_store_cmk_arn :
+    var.parameter_store_default_key
   ) : var.parameter_store_default_key
 
   calculated_ebs_kms_key_arn = var.create_ebs_kms_key ? (
-    var.ebs_external_kms_key != ""
-    ? var.ebs_external_kms_key
-    : (
-      module.graphdb.ebs_kms_key_arn != ""
-      ? module.graphdb.ebs_kms_key_arn
-      : var.ebs_default_kms_key
-    )
+    var.ebs_external_kms_key != "" ? var.ebs_external_kms_key :
+    module.graphdb.ebs_kms_key_arn != "" ? module.graphdb.ebs_kms_key_arn :
+    var.ebs_default_kms_key
   ) : var.ebs_default_kms_key
 
   calculated_s3_kms_key_arn = var.create_s3_kms_key ? (
-    var.s3_external_kms_key_arn != ""
-    ? var.s3_external_kms_key_arn
-    : (
-      module.backup[0].s3_cmk_arn != ""
-      ? module.backup[0].s3_cmk_arn
-      : var.s3_kms_default_key
-    )
+    var.s3_external_kms_key_arn != "" ? var.s3_external_kms_key_arn :
+    module.backup[0].s3_cmk_arn != "" ? module.backup[0].s3_cmk_arn :
+    var.s3_kms_default_key
   ) : var.s3_kms_default_key
 
   calculated_sns_kms_key_arn = var.create_sns_kms_key ? (
-    var.sns_external_kms_key != ""
-    ? var.sns_external_kms_key
-    : (
-      module.monitoring[0].sns_cmk_arn != ""
-      ? module.monitoring[0].sns_cmk_arn
-      : var.sns_default_kms_key
-    )
+    var.sns_external_kms_key != "" ? var.sns_external_kms_key :
+    module.monitoring[0].sns_cmk_arn != "" ? module.monitoring[0].sns_cmk_arn :
+    var.sns_default_kms_key
   ) : var.sns_default_kms_key
 
   cmk_key_alias = var.deploy_monitoring ? (
     var.app_name != "" && var.environment_name != ""
     ? "alias/${var.app_name}-${var.environment_name}-graphdb-sns-cmk-alias"
-  : var.sns_cmk_key_alias) : null
+    : var.sns_cmk_key_alias
+  ) : null
 
   # TLS & Protocol
   lb_tls_enabled      = var.lb_tls_certificate_arn != "" ? true : false
@@ -55,63 +52,84 @@ locals {
 
   # Subnet CIDR lists
   effective_private_subnet_cidrs = var.graphdb_node_count == 1 ? [var.vpc_private_subnet_cidrs[0]] : var.vpc_private_subnet_cidrs
-  effective_public_subnet_cidrs  = var.graphdb_node_count == 1 ? [var.vpc_public_subnet_cidrs[0]] : var.vpc_public_subnet_cidrs
+
+  effective_public_subnet_cidrs = var.graphdb_node_count == 1 ? [var.vpc_public_subnet_cidrs[0]] : var.vpc_public_subnet_cidrs
 
   lb_subnets = var.existing_lb_arn != "" ? var.existing_lb_subnets : (
-    var.graphdb_node_count == 1
-    ? (
-      var.vpc_id == ""
-      ? (
-        var.lb_internal
-        ? [module.vpc[0].private_subnet_ids[0]]
-        : [module.vpc[0].public_subnet_ids[0]]
+    var.graphdb_node_count == 1 ? (
+      var.vpc_id == "" ? (
+        var.lb_internal ? [module.vpc[0].private_subnet_ids[0]] : [module.vpc[0].public_subnet_ids[0]]
+        ) : (
+        var.lb_internal ? [var.vpc_private_subnet_ids[0]] : [var.vpc_public_subnet_ids[0]]
       )
-      : (
-        var.lb_internal
-        ? [var.vpc_private_subnet_ids[0]]
-        : [var.vpc_public_subnet_ids[0]]
-      )
-    )
-    : (
-      var.vpc_id == ""
-      ? (
-        var.lb_internal
-        ? module.vpc[0].private_subnet_ids
-        : module.vpc[0].public_subnet_ids
-      )
-      : (
-        var.lb_internal
-        ? var.vpc_private_subnet_ids
-        : var.vpc_public_subnet_ids
+      ) : (
+      var.vpc_id == "" ? (
+        var.lb_internal ? module.vpc[0].private_subnet_ids : module.vpc[0].public_subnet_ids
+        ) : (
+        var.lb_internal ? var.vpc_private_subnet_ids : var.vpc_public_subnet_ids
       )
     )
   )
 
-  graphdb_subnets = var.graphdb_node_count == 1 ? [
-    (var.vpc_id != ""
-      ? var.vpc_private_subnet_ids
-      : module.vpc[0].private_subnet_ids
-    )[0]
-    ] : (
-    var.vpc_id != ""
-    ? var.vpc_private_subnet_ids
-    : module.vpc[0].private_subnet_ids
-  )
-
+  graphdb_subnets = var.graphdb_node_count == 1 ? [(var.vpc_id != "" ? var.vpc_private_subnet_ids
+    : module.vpc[0].private_subnet_ids)[0]] : (var.vpc_id != "" ? var.vpc_private_subnet_ids
+  : module.vpc[0].private_subnet_ids)
 
   # Load Balancer ARNs & DNS
   lb_arn_list = var.existing_lb_arn != "" ? [var.existing_lb_arn] : module.load_balancer[*].lb_arn
 
   lb_tg_arn_list = (
-    var.existing_lb_target_group_arns != null
-    && length(var.existing_lb_target_group_arns) > 0
+    var.existing_lb_target_group_arns != null &&
+    length(var.existing_lb_target_group_arns) > 0
   ) ? var.existing_lb_target_group_arns : module.load_balancer[*].lb_target_group_arn
 
   lb_dns = var.existing_lb_dns_name != "" ? var.existing_lb_dns_name : (
-    var.graphdb_external_dns != ""
-    ? var.graphdb_external_dns
-    : try(module.load_balancer[0].lb_dns_name, "")
+    var.graphdb_external_dns != "" ? var.graphdb_external_dns :
+    try(module.load_balancer[0].lb_dns_name, "")
   )
+
+  # Admin ARNs from IAM group
+  admin_user_arns = var.iam_admin_group != "" && length(data.aws_iam_group.iam_admin_group[0].users) > 0 ? [
+  for user in data.aws_iam_group.iam_admin_group[0].users : user.arn] : []
+
+  # Key Admin Logic
+  ebs_key_admin_arn = (
+    length(local.admin_user_arns) > 0
+    ? local.admin_user_arns
+    : can(tolist(var.ebs_key_admin_arn))
+    ? tolist(var.ebs_key_admin_arn)
+    : [var.ebs_key_admin_arn]
+  )
+
+  s3_key_admin_arn = (
+    length(local.admin_user_arns) > 0
+    ? local.admin_user_arns
+    : can(tolist(var.s3_kms_key_admin_arn))
+    ? tolist(var.s3_kms_key_admin_arn)
+    : [var.s3_kms_key_admin_arn]
+  )
+
+  sns_key_admin_arn = (
+    length(local.admin_user_arns) > 0
+    ? local.admin_user_arns
+    : can(tolist(var.sns_key_admin_arn))
+    ? tolist(var.sns_key_admin_arn)
+    : [var.sns_key_admin_arn]
+  )
+
+  parameter_store_key_admin_arn = (
+    length(local.admin_user_arns) > 0
+    ? local.admin_user_arns
+    : can(tolist(var.parameter_store_key_admin_arn))
+    ? tolist(var.parameter_store_key_admin_arn)
+    : [var.parameter_store_key_admin_arn]
+  )
+
+  # Comma-joined ARNs for modules expecting string input
+  ebs_key_admin_arn_joined             = join(",", local.ebs_key_admin_arn)
+  s3_key_admin_arn_joined              = join(",", local.s3_key_admin_arn)
+  sns_key_admin_arn_joined             = join(",", local.sns_key_admin_arn)
+  parameter_store_key_admin_arn_joined = join(",", local.parameter_store_key_admin_arn)
 }
 
 module "vpc" {
@@ -153,7 +171,7 @@ module "backup" {
   create_s3_kms_key              = var.create_s3_kms_key
   s3_default_kms_key             = var.s3_kms_default_key
   s3_cmk_alias                   = var.s3_cmk_alias
-  s3_kms_key_admin_arn           = var.s3_kms_key_admin_arn
+  s3_kms_key_admin_arn           = local.s3_key_admin_arn_joined
   s3_cmk_description             = var.s3_cmk_description
   s3_key_specification           = var.s3_key_specification
   s3_kms_key_enabled             = var.s3_kms_key_enabled
@@ -270,7 +288,7 @@ module "monitoring" {
   sns_endpoint_auto_confirms             = var.monitoring_endpoint_auto_confirms
   sns_protocol                           = var.monitoring_sns_protocol
   sns_cmk_description                    = var.sns_cmk_description
-  sns_key_admin_arn                      = var.sns_key_admin_arn
+  sns_key_admin_arn                      = local.sns_key_admin_arn_joined
   enable_sns_kms_key                     = var.create_sns_kms_key
   sns_external_kms_key                   = var.sns_external_kms_key
   rotation_enabled                       = var.sns_rotation_enabled
@@ -369,7 +387,7 @@ module "graphdb" {
   ebs_key_deletion_window_in_days = var.ebs_key_deletion_window_in_days
   ebs_key_arn                     = local.calculated_ebs_kms_key_arn
 
-  ebs_key_admin_arn   = var.ebs_key_admin_arn
+  ebs_key_admin_arn   = local.ebs_key_admin_arn_joined
   ebs_cmk_alias       = var.ebs_cmk_alias
   ebs_default_kms_key = var.default_ebs_cmk_alias
 
@@ -409,7 +427,7 @@ module "graphdb" {
 
   create_parameter_store_kms_key              = var.create_parameter_store_kms_key
   parameter_store_cmk_alias                   = var.parameter_store_cmk_alias
-  parameter_store_key_admin_arn               = var.parameter_store_key_admin_arn
+  parameter_store_key_admin_arn               = local.parameter_store_key_admin_arn_joined
   parameter_store_cmk_description             = var.parameter_store_cmk_description
   parameter_store_key_spec                    = var.parameter_store_key_spec
   parameter_store_key_enabled                 = var.parameter_store_key_enabled

--- a/modules/backup/cmk.tf
+++ b/modules/backup/cmk.tf
@@ -55,7 +55,7 @@ resource "aws_kms_key_policy" "s3_cmk_policy" {
         "Sid" : "Allow Key Administrators",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : var.s3_kms_key_admin_arn != "" ? var.s3_kms_key_admin_arn : "${aws_iam_role.graphdb_s3_key_admin_role.arn}"
+          "AWS" = length(trimspace(var.s3_kms_key_admin_arn)) > 0 ? split(",", var.s3_kms_key_admin_arn) : [aws_iam_role.graphdb_s3_key_admin_role.arn]
         },
         "Action" : [
           "kms:Create*",
@@ -78,7 +78,7 @@ resource "aws_kms_key_policy" "s3_cmk_policy" {
         "Sid" : "Allow S3 Use of the Key",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : var.s3_kms_key_admin_arn != "" ? var.s3_kms_key_admin_arn : "${aws_iam_role.graphdb_s3_key_admin_role.arn}"
+          "AWS" = length(trimspace(var.s3_kms_key_admin_arn)) > 0 ? split(",", var.s3_kms_key_admin_arn) : [aws_iam_role.graphdb_s3_key_admin_role.arn]
         },
         "Action" : [
           "kms:Encrypt",

--- a/modules/graphdb/cmk-ebs.tf
+++ b/modules/graphdb/cmk-ebs.tf
@@ -58,7 +58,7 @@ resource "aws_kms_key_policy" "ebs_cmk_policy" {
         "Sid" : "Allow access to the key for Key Administrators",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : var.ebs_key_admin_arn != "" ? var.ebs_key_admin_arn : "${aws_iam_role.ebs_key_admin_role.arn}"
+          "AWS" = length(trimspace(var.ebs_key_admin_arn)) > 0 ? split(",", var.ebs_key_admin_arn) : [aws_iam_role.ebs_key_admin_role.arn]
         },
         "Action" : [
           "kms:Create*",

--- a/modules/graphdb/cmk-parameter-store.tf
+++ b/modules/graphdb/cmk-parameter-store.tf
@@ -58,7 +58,7 @@ resource "aws_kms_key_policy" "parameter_store_cmk_policy" {
         "Sid" : "Allow access for Key Administrators",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : var.parameter_store_key_admin_arn != "" ? var.parameter_store_key_admin_arn : aws_iam_role.param_store_key_admin_role.arn
+          "AWS" = length(trimspace(var.parameter_store_key_admin_arn)) > 0 ? split(",", var.parameter_store_key_admin_arn) : [aws_iam_role.param_store_key_admin_role.arn]
         },
         "Action" : [
           "kms:CreateAlias",

--- a/modules/graphdb/templates/00_functions.sh
+++ b/modules/graphdb/templates/00_functions.sh
@@ -5,6 +5,8 @@ log_with_timestamp() {
   echo "$(date '+%Y-%m-%d %H:%M:%S'): $1"
 }
 
+ENABLE_ASG_WAIT=${enable_asg_wait}
+
 # Function to check ASG node counts
 wait_for_asg_nodes() {
   local ASG_NAME="$1"

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -23,6 +23,7 @@ data "cloudinit_config" "graphdb_user_data" {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/templates/00_functions.sh", {
       name : var.resource_name_prefix
+      enable_asg_wait = var.enable_asg_wait
     })
   }
 
@@ -31,6 +32,7 @@ data "cloudinit_config" "graphdb_user_data" {
     content = templatefile("${path.module}/templates/01_wait_node_count.sh.tpl", {
       name : var.resource_name_prefix
       node_count : var.graphdb_node_count
+      enable_asg_wait : var.enable_asg_wait
     })
   }
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -420,3 +420,8 @@ variable "additional_policy_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_asg_wait" {
+  description = "Whether to enable waiting for ASG node readiness"
+  type        = string
+}

--- a/modules/monitoring/alarms.tf
+++ b/modules/monitoring/alarms.tf
@@ -85,9 +85,9 @@ resource "aws_cloudwatch_metric_alarm" "heap_usage_alarm" {
   for_each = toset(local.instance_hostnames)
 
   alarm_name          = "al-${var.resource_name_prefix}-heap-memory-usage-${each.key}"
-  alarm_description   = "Triggers if ${each.key}'s heap usage exceeds 80% of its total memory"
+  alarm_description   = "Triggers if ${each.key}'s heap usage exceeds threshold of its total memory"
   comparison_operator = "GreaterThanThreshold"
-  threshold           = 80
+  threshold           = var.graphdb_memory_utilization_threshold
   evaluation_periods  = 1
   treat_missing_data  = "missing"
   alarm_actions       = [aws_sns_topic.graphdb_sns_topic.arn]
@@ -140,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "graphdb_cpu_utilization" {
   evaluation_periods  = var.cloudwatch_evaluation_periods
   period              = var.cloudwatch_period
   statistic           = "Maximum"
-  threshold           = 80
+  threshold           = var.cloudwatch_cpu_utilization_threshold
   alarm_actions       = [aws_sns_topic.graphdb_sns_topic.arn]
 
   metric_name = "CPUUtilization"

--- a/modules/monitoring/cmk.tf
+++ b/modules/monitoring/cmk.tf
@@ -63,7 +63,7 @@ resource "aws_kms_key_policy" "sns_cmk_policy" {
         "Sid" : "Allow access for Key Administrators",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : var.sns_key_admin_arn != "" ? var.sns_key_admin_arn : aws_iam_role.sns_key_admin_role.arn
+          "AWS" = length(trimspace(var.sns_key_admin_arn)) > 0 ? split(",", var.sns_key_admin_arn) : [aws_iam_role.sns_key_admin_role.arn]
         },
         "Action" : [
           "kms:CreateAlias",

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -68,12 +68,6 @@ variable "cloudwatch_log_group_retention_in_days" {
   type        = number
 }
 
-variable "cloudwatch_al_low_memory_warning_threshold" {
-  description = "Percentage of available used heap memory to monitor for"
-  type        = number
-  default     = 90
-}
-
 variable "route53_availability_port" {
   description = "Which HTTP port to use for the web availability tests"
   type        = number
@@ -201,4 +195,14 @@ variable "lb_dns_name" {
 variable "enable_availability_tests" {
   description = "Enable Route 53 availability tests and alarms"
   type        = bool
+}
+
+variable "cloudwatch_cpu_utilization_threshold" {
+  description = "Alarm threshold for Cloudwatch CPU Utilization"
+  type        = number
+}
+
+variable "graphdb_memory_utilization_threshold" {
+  description = "Alarm threshold for GraphDB Memory Utilization"
+  type        = number
 }

--- a/variables.tf
+++ b/variables.tf
@@ -881,3 +881,8 @@ variable "sns_rotation_enabled" {
   default     = true
 }
 
+variable "iam_admin_group" {
+  description = "Define IAM group that should have access to the KMS keys and other resources"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -468,6 +468,18 @@ variable "monitoring_enable_availability_tests" {
   default     = true
 }
 
+variable "monitoring_cpu_utilization_threshold" {
+  description = "Alarm threshold for Cloudwatch CPU Utilization"
+  type        = number
+  default     = 80
+}
+
+variable "monitoring_memory_utilization_threshold" {
+  description = "Alarm threshold for GraphDB Memory Utilization"
+  type        = number
+  default     = 80
+}
+
 # GraphDB overrides
 
 variable "graphdb_properties_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -633,6 +633,12 @@ variable "graphdb_user_supplied_templates" {
   default = []
 }
 
+variable "enable_asg_wait" {
+  description = "Whether to enable waiting for ASG node readiness"
+  type        = string
+  default     = "true"
+}
+
 # S3 bucket encryption
 
 variable "create_s3_kms_key" {


### PR DESCRIPTION
## Description

- Enabled dynamic inclusion of IAM group members as KMS administrators for easier management and access control.
- Users can now customize CPU and Memory Utilization thresholds for CloudWatch alarms, allowing fine-tuned scaling behavior. 
- Introduced a flag to enable or disable the ASG_WAIT_NODE function, offering flexibility for single-node or fast-scaling environments.

## Related Issues

[GDB-12341]
[GDB-12376]
[GDB-12377]

## Changes

- Added ability to use IAM Group for KMS Key Admin
- Added ability to change threshold for CPU, Mem Utilization alarms
- Introduced ability to disable/enable the ASG_WAIT_NODE function

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-12341]: https://graphwise.atlassian.net/browse/GDB-12341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12376]: https://graphwise.atlassian.net/browse/GDB-12376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDB-12377]: https://graphwise.atlassian.net/browse/GDB-12377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ