### PR TITLE
GDB-12470: Update GraphDB version to 10.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 1.5.2
+
+* Update default GraphDB version to [10.8.8](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-8)
+
 ## 1.5.1
 
 * Update default GraphDB version to [10.8.7](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-7)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | vpc\_flow\_logs\_expiration\_days | Define the days after which the VPC flow logs should be deleted | `number` | `7` | no |
 | lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false` | no |
 | ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null` | no |
-| graphdb\_version | GraphDB version | `string` | `"10.8.7"` | no |
+| graphdb\_version | GraphDB version | `string` | `"10.8.8"` | no |
 | device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"` | no |
 | ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"` | no |
 | ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -270,7 +270,7 @@ variable "ami_id" {
 variable "graphdb_version" {
   description = "GraphDB version"
   type        = string
-  default     = "10.8.7"
+  default     = "10.8.8"
   nullable    = false
 }
 


### PR DESCRIPTION
Updated the default GraphDB version to the latest patch version for 10.x
