### PR TITLE
Update TG name generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 4.0.0
+
+**BREAKING CHANGE**: Target group name format has changed from `{prefix}-tg-{flavor}-{suffix}` to `{prefix}-{suffix}` to stay within AWS's 32-character name limit. Existing deployments will have their target group destroyed and recreated.
+
 ## 3.2.2
 
 * Updated GraphDB default version to [11.3.3](https://graphdb.ontotext.com/documentation/11.3/release-notes.html#graphdb-11-3-3)

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -4,7 +4,7 @@ locals {
 
   lb_flavor                   = local.is_alb ? "alb" : "nlb"
   lb_name                     = "${var.resource_name_prefix}-${local.lb_flavor}"
-  target_group_name           = "${var.resource_name_prefix}-tg-${local.lb_flavor}-${random_id.tg_name_suffix.hex}"
+  target_group_name           = "${var.resource_name_prefix}-${random_id.tg_name_suffix.hex}"
   graphdb_backend_health_path = var.graphdb_node_count > 1 ? var.lb_health_check_path : "/protocol"
   lb_context_path_clean       = trim(var.lb_context_path, "/")
   lb_context_path_norm        = local.lb_context_path_clean != "" ? "/${local.lb_context_path_clean}" : ""


### PR DESCRIPTION
## Description

* Updated the TG name generation process to prevent errors caused by overly long names, capping them at 32 characters.

## Related Issues

## Changes

* Updated the TG name generation process to prevent errors caused by overly long names, capping them at 32 characters.

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
