### PR TITLE
Updates and anchors the GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       security-events: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Terraform CLI
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Run Terraform init
         run: terraform init
@@ -31,12 +31,12 @@ jobs:
         run: terraform validate
 
       - name: Run tfsec
-        uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        uses: aquasecurity/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608 # v0.1.4
         with:
           config_file: tfsec.yml
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a #v2.25.4
         with:
           sarif_file: tfsec.sarif

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,14 @@ jobs:
     steps:
       - id: clone_repository
         name: Clone repository
-        # actions/checkout@v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - id: run_terraform_docs
         name: Render terraform docs and push changes back to PR
         # terraform-docs/gh-actions@1.0.0
-        uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           working-dir: .
           output-file: README.md


### PR DESCRIPTION
- Updated the version of all GitHub Actions to their latest available.

  This is done in order to solve an warning about deprecated container images that the some of the actions are using.

  Also, the versions are now anchored to specific SHA tag, which "allegedly" is more secured.
