### PR TITLE
Update GDB to 13.4.0. Add Data Encryption at Rest

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -44,24 +44,22 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
-  version = "2.3.5"
+  version = "2.4.0"
   hashes = [
-    "h1:HCoabXm6NQwCivl1q24+l9VUufc2mFqNeulsQBA9iFg=",
-    "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
-    "h1:TUljFfEUFn6szDfglwv150tNRUKPgqa5YiCTdF9Tc6c=",
-    "h1:wbw64JlCobcQCAdlzHpxksQ1GabewTW1yxnACBVZh4A=",
-    "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
-    "zh:348664d9a900f7baf7b091cf94d657e4c968b240d31d9e162086724e6afc19d5",
-    "zh:5a876a468ffabff0299f8348e719cb704daf81a4867f8c6892f3c3c4add2c755",
-    "zh:6ef97ee4c8c6a69a3d36746ba5c857cf4f4d78f32aa3d0e1ce68f2ece6a5dba5",
+    "h1:Bx3XQkBSY3RAGwLZb8hyi8AhvahPNlt4mlyZhW9guOI=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8283e5a785e3c518a440f6ac6e7cc4fc07fe266bf34974246f4e2ef05762feda",
-    "zh:a44eb5077950168b571b7eb65491246c00f45409110f0f172cc3a7605f19dba9",
-    "zh:aa0806cbff72b49c1b389c0b8e6904586e5259c08dabb7cb5040418568146530",
-    "zh:bec4613c3beaad9a7be7ca99cdb2852073f782355b272892e6ee97a22856aec1",
-    "zh:d7fe368577b6c8d1ae44c751ed42246754c10305c7f001cc0109833e95aa107d",
-    "zh:df2409fc6a364b1f0a0f8a9cd8a86e61e80307996979ce3790243c4ce88f2915",
-    "zh:ed3c263396ff1f4d29639cc43339b655235acf4d06296a7c120a80e4e0fd6409",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
   ]
 }
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,11 @@ To enable deployment of the monitoring module, you need to enable the following 
 deploy_monitoring = true
 ```
 
+
+**Encryption at Rest**
+
+Starting from 11.4.0, GraphDB supports encryption at rest (See [here]()). To configure encryption at rest
+
 ### Microsoft Entra ID (Azure AD) Integration
 
 This module supports Microsoft Entra ID (formerly Azure AD) authentication for GraphDB. When enabled, users can authenticate using their Entra ID credentials, and machine-to-machine (M2M) authentication is used for automated operations like backups and cluster management.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ deploy_monitoring = true
 
 **Encryption at Rest**
 
-Starting from 11.4.0, GraphDB supports encryption at rest (See [here]()). To configure encryption at rest
+Starting from 11.4.0, GraphDB supports encryption at rest (See [here](TODO)). To configure encryption at rest
 
 ### Microsoft Entra ID (Azure AD) Integration
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | tgw\_enable\_propagation | Whether to enable propagation of this attachment into tgw\_route\_table\_id. | `bool` | `null` | no |
 | lb\_enable\_private\_access | Enable or disable the private access via PrivateLink to the GraphDB Cluster | `bool` | `false` | no |
 | ami\_id | (Optional) User-provided AMI ID to use with GraphDB instances. If you provide this value, please ensure it will work with the default userdata script (assumes latest version of Ubuntu LTS). Otherwise, please provide your own userdata script using the user\_supplied\_userdata\_path variable. | `string` | `null` | no |
-| graphdb\_version | GraphDB version | `string` | `"11.3.3"` | no |
+| graphdb\_version | GraphDB version | `string` | `"11.4.0"` | no |
 | device\_name | The device to which EBS volumes for the GraphDB data directory will be mapped. | `string` | `"/dev/sdf"` | no |
 | ebs\_volume\_type | Type of the EBS volumes, used by the GraphDB nodes. | `string` | `"gp3"` | no |
 | ebs\_volume\_size | The size of the EBS volumes, used by the GraphDB nodes. | `number` | `500` | no |
@@ -287,6 +287,11 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | m2m\_app\_registration\_client\_id | The M2M App registration client ID | `string` | `null` | no |
 | m2m\_app\_registration\_client\_secret | The M2M App registration client secret | `string` | `null` | no |
 | m2m\_scope | The scope for the M2M application | `string` | `null` | no |
+| graphdb\_data\_encryption\_type | The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12 | `string` | `""` | no |
+| graphdb\_data\_encryption\_master\_key\_filepath | The master key, when using file-based data encryption. | `string` | `""` | no |
+| graphdb\_data\_encryption\_keystore\_alias | The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12) | `string` | n/a | yes |
+| graphdb\_data\_encryption\_keystore\_filepath | Local path to a keystore file containing the master key for encryption at rest setup | `string` | `""` | no |
+| graphdb\_data\_encryption\_keystore\_password | The keystore password for the data encryption keystore (when using type pkcs12) | `string` | `""` | no |
 <!-- END_TF_DOCS -->
 
 ## Usage

--- a/main.tf
+++ b/main.tf
@@ -236,15 +236,16 @@ module "graphdb" {
 
   # GraphDB Configurations
 
-  graphdb_admin_password                    = var.graphdb_admin_password
-  graphdb_cluster_token                     = var.graphdb_cluster_token
-  graphdb_properties_path                   = var.graphdb_properties_path
-  graphdb_java_options                      = var.graphdb_java_options
-  graphdb_license_path                      = var.graphdb_license_path
-  graphdb_data_encryption_type              = var.graphdb_data_encryption_type
-  graphdb_data_encryption_keystore_password = var.graphdb_data_encryption_keystore_password
-  graphdb_data_encryption_keystore_alias    = var.graphdb_data_encryption_keystore_alias
-  graphdb_data_encryption_master_key_secret = var.graphdb_data_encryption_master_key_secret
+  graphdb_admin_password                      = var.graphdb_admin_password
+  graphdb_cluster_token                       = var.graphdb_cluster_token
+  graphdb_properties_path                     = var.graphdb_properties_path
+  graphdb_java_options                        = var.graphdb_java_options
+  graphdb_license_path                        = var.graphdb_license_path
+  graphdb_data_encryption_type                = var.graphdb_data_encryption_type
+  graphdb_data_encryption_keystore_password   = var.graphdb_data_encryption_keystore_password
+  graphdb_data_encryption_keystore_filepath   = var.graphdb_data_encryption_keystore_filepath
+  graphdb_data_encryption_keystore_alias      = var.graphdb_data_encryption_keystore_alias
+  graphdb_data_encryption_master_key_filepath = var.graphdb_data_encryption_master_key_filepath
 
   # VMs
 

--- a/main.tf
+++ b/main.tf
@@ -236,11 +236,14 @@ module "graphdb" {
 
   # GraphDB Configurations
 
-  graphdb_admin_password  = var.graphdb_admin_password
-  graphdb_cluster_token   = var.graphdb_cluster_token
-  graphdb_properties_path = var.graphdb_properties_path
-  graphdb_java_options    = var.graphdb_java_options
-  graphdb_license_path    = var.graphdb_license_path
+  graphdb_admin_password                        = var.graphdb_admin_password
+  graphdb_cluster_token                         = var.graphdb_cluster_token
+  graphdb_properties_path                       = var.graphdb_properties_path
+  graphdb_java_options                          = var.graphdb_java_options
+  graphdb_license_path                          = var.graphdb_license_path
+  graphdb_data_encryption_type                  = var.graphdb_data_encryption_type
+  graphdb_data_encryption_keystore_password     = var.graphdb_data_encryption_keystore_password
+  graphdb_data_encryption_keystore_alias        = var.graphdb_data_encryption_keystore_alias
 
   # VMs
 

--- a/main.tf
+++ b/main.tf
@@ -244,6 +244,7 @@ module "graphdb" {
   graphdb_data_encryption_type                  = var.graphdb_data_encryption_type
   graphdb_data_encryption_keystore_password     = var.graphdb_data_encryption_keystore_password
   graphdb_data_encryption_keystore_alias        = var.graphdb_data_encryption_keystore_alias
+  graphdb_data_encryption_master_key_secret     = var.graphdb_data_encryption_master_key_secret
 
   # VMs
 

--- a/main.tf
+++ b/main.tf
@@ -236,15 +236,15 @@ module "graphdb" {
 
   # GraphDB Configurations
 
-  graphdb_admin_password                        = var.graphdb_admin_password
-  graphdb_cluster_token                         = var.graphdb_cluster_token
-  graphdb_properties_path                       = var.graphdb_properties_path
-  graphdb_java_options                          = var.graphdb_java_options
-  graphdb_license_path                          = var.graphdb_license_path
-  graphdb_data_encryption_type                  = var.graphdb_data_encryption_type
-  graphdb_data_encryption_keystore_password     = var.graphdb_data_encryption_keystore_password
-  graphdb_data_encryption_keystore_alias        = var.graphdb_data_encryption_keystore_alias
-  graphdb_data_encryption_master_key_secret     = var.graphdb_data_encryption_master_key_secret
+  graphdb_admin_password                    = var.graphdb_admin_password
+  graphdb_cluster_token                     = var.graphdb_cluster_token
+  graphdb_properties_path                   = var.graphdb_properties_path
+  graphdb_java_options                      = var.graphdb_java_options
+  graphdb_license_path                      = var.graphdb_license_path
+  graphdb_data_encryption_type              = var.graphdb_data_encryption_type
+  graphdb_data_encryption_keystore_password = var.graphdb_data_encryption_keystore_password
+  graphdb_data_encryption_keystore_alias    = var.graphdb_data_encryption_keystore_alias
+  graphdb_data_encryption_master_key_secret = var.graphdb_data_encryption_master_key_secret
 
   # VMs
 

--- a/modules/graphdb/config.tf
+++ b/modules/graphdb/config.tf
@@ -53,6 +53,16 @@ locals {
       substr(md5(base64encode(var.m2m_app_registration_client_secret)), 0, 12),
       16
     ) : 1
+
+    keystore = var.graphdb_data_encryption_keystore_filepath != "" ? parseint(
+      substr(md5(filebase64(var.graphdb_data_encryption_keystore_filepath)), 0, 12),
+      16
+    ) : 1
+
+    master_key = var.graphdb_data_encryption_master_key_filepath != "" ? parseint(
+      substr(md5(filebase64(var.graphdb_data_encryption_master_key_filepath)), 0, 12),
+      16
+    ) : 1
   }
 }
 
@@ -115,3 +125,27 @@ resource "aws_ssm_parameter" "graphdb_m2m_client_secret" {
   value_wo_version = local.graphdb_ssm_versions.m2m_client_secret
   key_id           = var.parameter_store_key_arn
 }
+
+resource "aws_ssm_parameter" "graphdb_data_encryption_keystore" {
+  count = var.graphdb_data_encryption_keystore_filepath != "" ? 1 : 0
+
+  name             = "/${var.resource_name_prefix}/graphdb/encryption_keystore"
+  description      = "Keystore containing the master key for encryption at rest setup"
+  type             = "SecureString"
+  value_wo         = filebase64(var.graphdb_data_encryption_keystore_filepath)
+  value_wo_version = local.graphdb_ssm_versions.keystore
+  key_id           = var.parameter_store_key_arn
+}
+
+
+resource "aws_ssm_parameter" "graphdb_data_encryption_master_key_filepath" {
+  count = var.graphdb_data_encryption_master_key_filepath != "" ? 1 : 0
+
+  name             = "/${var.resource_name_prefix}/graphdb/encryption_master_key"
+  description      = "Master key for encryption at rest setup"
+  type             = "SecureString"
+  value_wo         = filebase64(var.graphdb_data_encryption_master_key_filepath)
+  value_wo_version = local.graphdb_ssm_versions.master_key
+  key_id           = var.parameter_store_key_arn
+}
+

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -168,7 +168,9 @@ if [[ -n "$DATA_ENCRYPTION_TYPE" ]]; then
    }
 
 EOF
-    ( cd /tmp && javac GenKey.java && java GenKey ${graphdb_data_encryption_keystore_password} ${graphdb_data_encryption_keystore_alias} && rm /tmp/GenKey.*)
+    PASS=${graphdb_data_encryption_keystore_password}
+    ALIAS=${graphdb_data_encryption_keystore_alias}
+    ( cd /tmp && javac GenKey.java && java GenKey $PASS $ALIAS && rm /tmp/GenKey.*)
     ENC_PROPS="-Dgraphdb.data.encryption.type=pkcs12 -Dgraphdb.data.encryption.file=/etc/master.p12 -Dgraphdb.data.encryption.keystore.alias=${graphdb_data_encryption_keystore_alias} -Dgraphdb.data.encryption.keystore.password=${graphdb_data_encryption_keystore_password}"
   else
     log_with_timestamp "Invalid or unsupported data encryption type: $DATA_ENCRYPTION_TYPE. Skipping data encryption"
@@ -176,7 +178,7 @@ fi
 
 # Appends environment overrides to GDB_JAVA_OPTS
 extra_graphdb_java_options="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_java_options" --with-decryption 2>/dev/null | jq -r .Parameter.Value || /bin/true )"
-if [[ -n ${ENC_PROPS} ]]; then
+if [[ -n $ENC_PROPS ]]; then
   extra_graphdb_java_options="$extra_graphdb_java_options $ENC_PROPS"
 fi
 

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -23,6 +23,7 @@ echo "#######################################"
 LB_DNS_RECORD=${graphdb_lb_dns_name}
 PROTOCOL=${external_address_protocol}
 CONTEXT_PATH="${lb_context_path}"
+DATA_ENCRYPTION_TYPE=${graphdb_data_encryption_type}
 
 # Construct the external URL with context path only if provided
 if [ -n "$CONTEXT_PATH" ]; then
@@ -30,6 +31,7 @@ if [ -n "$CONTEXT_PATH" ]; then
 else
   EXTERNAL_URL="$${PROTOCOL}://$${LB_DNS_RECORD}"
 fi
+
 
 # Get and store the GraphDB license
 aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/license" --with-decryption | \
@@ -122,8 +124,62 @@ log_with_timestamp "GraphDB audit log configuration completed"
 GDB_PROPERTIES=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_properties" --with-decryption 2>/dev/null | jq -r .Parameter.Value | base64 -d || /bin/true)
 [[ -n $GDB_PROPERTIES ]] && echo "$GDB_PROPERTIES" >> /etc/graphdb/graphdb.properties
 
+ENC_PROPS=""
+if [[ -n "$DATA_ENCRYPTION_TYPE" ]]; then
+  if [[ "$DATA_ENCRYPTION_TYPE" = "file" ]]; then
+    log_with_timestamp "Configuring file-based data encryption."
+    log_with_timestamp "Generating master key and storing it to /etc/master.key"
+    echo -n "${graphdb_master_key_secret}" | openssl dgst -sha256 -binary > /etc/master.key
+    chmod a-wx,o-rwx /etc/master.key
+    ENC_PROPS="-Dgraphdb.data.encryption.type=file -Dgraphdb.data.encryption.file=/etc/master.key"
+  elif [[ "$DATA_ENCRYPTION_TYPE" = "pkcs12" ]]; then
+    log_with_timestamp "Configuring pkcs12-based data encryption"
+    log_with_timestamp "Generating keystore and storing it to /etc/master.p12"
+    cat << EOF > /tmp/GenKey.java
+   import javax.crypto.SecretKey;
+   import javax.crypto.SecretKeyFactory;
+   import javax.crypto.spec.PBEKeySpec;
+   import javax.crypto.spec.SecretKeySpec;
+   import java.security.SecureRandom;
+   import java.io.FileOutputStream;
+   import java.security.KeyStore;
+
+   public class AESKeyGenerator {
+
+        public static SecretKey generateKeyFromString(String password, byte[] salt)
+               throws Exception {
+           PBEKeySpec spec = new PBEKeySpec(password.toCharArray(),salt,65536,256);
+           return new SecretKeySpec(SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec).getEncoded(), "AES");
+       }
+       public static void main(String[] args) throws Exception {
+           byte[] salt = new byte[] {
+               0x73, 0x61, 0x6C, 0x74, 0x44, 0x6F, 0x67, 0x21
+           }; // "saltDog!"
+           SecretKey key = generateKeyFromString(password, salt);
+           char[] passwordChars = args[0].toCharArray();
+           KeyStore.PasswordProtection password = new KeyStore.PasswordProtection(passwordChars);
+           KeyStore ks = KeyStore.getInstance("PKCS12");
+           ks.load(null, null);
+           ks.setEntry(args[1], entry, passwordChars);
+           try (FileOutputStream fos = new FileOutputStream("/etc/master.p12")) {
+               ks.store(fos, passwordChars);
+           }
+       }
+   }
+
+EOF
+    ( cd /tmp && javac GenKey.java && java GenKey ${graphdb_data_encryption_keystore_password} ${graphdb_data_encryption_keystore_alias} && rm /tmp/GenKey.*)
+    ENC_PROPS="-Dgraphdb.data.encryption.type=pkcs12 -Dgraphdb.data.encryption.file=/etc/master.p12 -Dgraphdb.data.encryption.keystore.alias=${graphdb_data_encryption_keystore_alias} -Dgraphdb.data.encryption.keystore.password=${graphdb_data_encryption_keystore_password}"
+  else
+    log_with_timestamp "Invalid or unsupported data encryption type: $DATA_ENCRYPTION_TYPE. Skipping data encryption"
+fi
+
 # Appends environment overrides to GDB_JAVA_OPTS
 extra_graphdb_java_options="$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_java_options" --with-decryption 2>/dev/null | jq -r .Parameter.Value || /bin/true )"
+if [[ -n ${ENC_PROPS} ]]; then
+  extra_graphdb_java_options="$extra_graphdb_java_options $ENC_PROPS"
+fi
+
 if [[ -n $extra_graphdb_java_options  ]]; then
   if grep GDB_JAVA_OPTS /etc/graphdb/graphdb.env &>/dev/null; then
     sed -ie "s|GDB_JAVA_OPTS=\"\(.*\)\"|GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"|g" /etc/graphdb/graphdb.env

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -32,7 +32,6 @@ else
   EXTERNAL_URL="$${PROTOCOL}://$${LB_DNS_RECORD}"
 fi
 
-
 # Get and store the GraphDB license
 aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/license" --with-decryption | \
   jq -r .Parameter.Value | \

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -132,48 +132,9 @@ if [[ -n "$DATA_ENCRYPTION_TYPE" ]]; then
     echo -n "${graphdb_master_key_secret}" | openssl dgst -sha256 -binary > /etc/master.key
     chmod a-wx,o-rwx /etc/master.key
     ENC_PROPS="-Dgraphdb.data.encryption.type=file -Dgraphdb.data.encryption.file=/etc/master.key"
-  elif [[ "$DATA_ENCRYPTION_TYPE" = "pkcs12" ]]; then
-    log_with_timestamp "Configuring pkcs12-based data encryption"
-    log_with_timestamp "Generating keystore and storing it to /etc/master.p12"
-    cat << EOF > /tmp/GenKey.java
-   import javax.crypto.SecretKey;
-   import javax.crypto.SecretKeyFactory;
-   import javax.crypto.spec.PBEKeySpec;
-   import javax.crypto.spec.SecretKeySpec;
-   import java.security.SecureRandom;
-   import java.io.FileOutputStream;
-   import java.security.KeyStore;
-
-   public class AESKeyGenerator {
-
-        public static SecretKey generateKeyFromString(String password, byte[] salt)
-               throws Exception {
-           PBEKeySpec spec = new PBEKeySpec(password.toCharArray(),salt,65536,256);
-           return new SecretKeySpec(SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec).getEncoded(), "AES");
-       }
-       public static void main(String[] args) throws Exception {
-           byte[] salt = new byte[] {
-               0x73, 0x61, 0x6C, 0x74, 0x44, 0x6F, 0x67, 0x21
-           }; // "saltDog!"
-           SecretKey key = generateKeyFromString(password, salt);
-           char[] passwordChars = args[0].toCharArray();
-           KeyStore.PasswordProtection password = new KeyStore.PasswordProtection(passwordChars);
-           KeyStore ks = KeyStore.getInstance("PKCS12");
-           ks.load(null, null);
-           ks.setEntry(args[1], entry, passwordChars);
-           try (FileOutputStream fos = new FileOutputStream("/etc/master.p12")) {
-               ks.store(fos, passwordChars);
-           }
-       }
-   }
-
-EOF
-    PASS=${graphdb_data_encryption_keystore_password}
-    ALIAS=${graphdb_data_encryption_keystore_alias}
-    ( cd /tmp && javac GenKey.java && java GenKey $PASS $ALIAS && rm /tmp/GenKey.*)
-    ENC_PROPS="-Dgraphdb.data.encryption.type=pkcs12 -Dgraphdb.data.encryption.file=/etc/master.p12 -Dgraphdb.data.encryption.keystore.alias=${graphdb_data_encryption_keystore_alias} -Dgraphdb.data.encryption.keystore.password=${graphdb_data_encryption_keystore_password}"
   else
     log_with_timestamp "Invalid or unsupported data encryption type: $DATA_ENCRYPTION_TYPE. Skipping data encryption"
+  fi
 fi
 
 # Appends environment overrides to GDB_JAVA_OPTS

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -103,7 +103,7 @@ cat << EOF > /etc/systemd/system/graphdb.service.d/overrides.conf
 Environment="GDB_HEAP_SIZE=$${JVM_MAX_MEMORY}g"
 EOF
 
-%{ if graphdb_enable_audit_log ~}
+%{ if graphdb_audit_log_enabled ~}
 log_with_timestamp "Configuring GraphDB audit log"
 cat << EOF >> /etc/graphdb/graphdb.properties
 graphdb.audit.log.enabled=true
@@ -127,10 +127,20 @@ ENC_PROPS=""
 if [[ -n "$DATA_ENCRYPTION_TYPE" ]]; then
   if [[ "$DATA_ENCRYPTION_TYPE" = "file" ]]; then
     log_with_timestamp "Configuring file-based data encryption."
-    log_with_timestamp "Generating master key and storing it to /etc/master.key"
-    echo -n "${graphdb_master_key_secret}" | openssl dgst -sha256 -binary > /etc/master.key
-    chmod a-wx,o-rwx /etc/master.key
-    ENC_PROPS="-Dgraphdb.data.encryption.type=file -Dgraphdb.data.encryption.file=/etc/master.key"
+    log_with_timestamp "Generating master key and storing it to /etc/graphdb/master.key"
+    aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/encryption_master_key" --with-decryption | \
+          jq -r .Parameter.Value | \
+          base64 -d > /etc/graphdb/master.key
+    chown graphdb:graphdb /etc/graphdb/master.key
+    chmod a-wx,o-rwx /etc/graphdb/master.key
+    ENC_PROPS="-Dgraphdb.data.encryption.type=file -Dgraphdb.data.encryption.file=/etc/graphdb/master.key"
+  elif [[ "$DATA_ENCRYPTION_TYPE" = "pkcs12" ]]; then
+    aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/encryption_keystore" --with-decryption | \
+      jq -r .Parameter.Value | \
+      base64 -d > /etc/graphdb/master.p12
+    chown graphdb:graphdb /etc/graphdb/master.p12
+    chmod a-wx,o-rwx /etc/graphdb/master.p12
+    ENC_PROPS="-Dgraphdb.data.encryption.type=pkcs12 -Dgraphdb.data.encryption.file=/etc/graphdb/master.p12 -Dgraphdb.data.encryption.keystore.alias=${graphdb_data_encryption_keystore_alias} -Dgraphdb.data.encryption.keystore.password=${graphdb_data_encryption_keystore_password}"
   else
     log_with_timestamp "Invalid or unsupported data encryption type: $DATA_ENCRYPTION_TYPE. Skipping data encryption"
   fi

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -124,6 +124,9 @@ data "cloudinit_config" "graphdb_user_data" {
       graphdb_audit_log_repository : var.graphdb_audit_log_repository
       graphdb_audit_log_headers : var.graphdb_audit_log_headers
       graphdb_audit_log_request_max_length : var.graphdb_audit_log_request_max_length
+      graphdb_data_encryption_type : var.graphdb_data_encryption_type
+      graphdb_data_encryption_keystore_alias : var.graphdb_data_encryption_keystore_alias
+      graphdb_data_encryption_keystore_password : var.graphdb_data_encryption_keystore_password
     })
   }
 

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -127,7 +127,7 @@ data "cloudinit_config" "graphdb_user_data" {
       graphdb_data_encryption_type : var.graphdb_data_encryption_type
       graphdb_data_encryption_keystore_alias : var.graphdb_data_encryption_keystore_alias
       graphdb_data_encryption_keystore_password : var.graphdb_data_encryption_keystore_password
-      graphdb_master_key_secret : var.graphdb_data_encryption_master_key_secret
+      graphdb_data_encryption_master_key_filepath : var.graphdb_data_encryption_master_key_filepath
     })
   }
 

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -127,6 +127,7 @@ data "cloudinit_config" "graphdb_user_data" {
       graphdb_data_encryption_type : var.graphdb_data_encryption_type
       graphdb_data_encryption_keystore_alias : var.graphdb_data_encryption_keystore_alias
       graphdb_data_encryption_keystore_password : var.graphdb_data_encryption_keystore_password
+      graphdb_master_key_secret : var.graphdb_data_encryption_master_key_secret
     })
   }
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -574,10 +574,9 @@ variable "graphdb_data_encryption_type" {
   type        = string
 }
 
-variable "graphdb_data_encryption_master_key_secret" {
-  description = "The master key secret, when using file-based data encryption."
+variable "graphdb_data_encryption_master_key_filepath" {
+  description = "The master key, when using file-based data encryption."
   type        = string
-  sensitive   = true
 }
 
 variable "graphdb_data_encryption_keystore_alias" {
@@ -590,4 +589,9 @@ variable "graphdb_data_encryption_keystore_password" {
   description = "The keystore password for the data encryption keystore (when using type pkcs12)"
   type        = string
   sensitive   = true
+}
+
+variable "graphdb_data_encryption_keystore_filepath" {
+  description = "Local path to a keystore file containing the master key for encryption at rest setup"
+  type        = string
 }

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -574,6 +574,12 @@ variable "graphdb_data_encryption_type" {
   type = string
 }
 
+variable "graphdb_data_encryption_master_key_secret" {
+  description = "The master key secret, when using file-based data encryption."
+  type = string
+  sensitive = true
+}
+
 variable "graphdb_data_encryption_keystore_alias" {
   description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
   type = string

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -571,23 +571,23 @@ variable "m2m_scope" {
 
 variable "graphdb_data_encryption_type" {
   description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
-  type = string
+  type        = string
 }
 
 variable "graphdb_data_encryption_master_key_secret" {
   description = "The master key secret, when using file-based data encryption."
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }
 
 variable "graphdb_data_encryption_keystore_alias" {
   description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
-  type = string
-  default = "masterkey"
+  type        = string
+  default     = "masterkey"
 }
 
 variable "graphdb_data_encryption_keystore_password" {
   description = "The keystore password for the data encryption keystore (when using type pkcs12)"
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -568,3 +568,20 @@ variable "m2m_scope" {
   description = "The scope for the M2M application"
   type        = string
 }
+
+variable "graphdb_data_encryption_type" {
+  description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
+  type = string
+}
+
+variable "graphdb_data_encryption_keystore_alias" {
+  description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
+  type = string
+  default = "masterkey"
+}
+
+variable "graphdb_data_encryption_keystore_password" {
+  description = "The keystore password for the data encryption keystore (when using type pkcs12)"
+  type = string
+  sensitive = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1289,9 +1289,22 @@ variable "graphdb_data_encryption_type" {
   type = string
   default = ""
   validation {
-    condition =
-      contains(["", "file", "pkcs12"], trimspace(var.graphdb_data_encryption_type)
-      error_message "graphdb_data_encryption_type can be either empty, 'file' or 'pkcs12'"
+    condition = contains(["", "file", "pkcs12"], var.graphdb_data_encryption_type)
+    error_message = "graphdb_data_encryption_type can be either empty, 'file' or 'pkcs12'"
+  }
+}
+
+variable "graphdb_data_encryption_master_key_secret" {
+  description = "The master key secret, when using file-based data encryption."
+  type = string
+  sensitive = true
+  default = ""
+  validation {
+    condition = (
+      var.graphdb_data_encryption_type == "file" &&
+      trimspace(var.graphdb_data_encryption_master_key_secret) != ""
+      )
+    error_message = "Must set master key secret when using file-based data encryption"
   }
 }
 
@@ -1305,12 +1318,11 @@ variable "graphdb_data_encryption_keystore_password" {
   description = "The keystore password for the data encryption keystore (when using type pkcs12)"
   type = string
   sensitive = true
-  default = null
+  default = ""
   validation {
       condition = (
-        var.graphdb_data_encryption_type == "pkcs12" &&
-        trimspace(var.graphdb_data_encryption_keystore_password) != ""
-        )
+        var.graphdb_data_encryption_type != "pkcs12"
+      ) ? true : trimspace(var.graphdb_data_encryption_keystore_password) != ""
       error_message = "PKCS12 Keystore password cannot be null when configuring PKCS12-based data encryption"
-    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1294,22 +1294,34 @@ variable "graphdb_data_encryption_type" {
   }
 }
 
-variable "graphdb_data_encryption_master_key_secret" {
-  description = "The master key secret, when using file-based data encryption."
+variable "graphdb_data_encryption_master_key_filepath" {
+  description = "The master key, when using file-based data encryption."
   type        = string
   sensitive   = true
   default     = ""
   validation {
     condition = (
       var.graphdb_data_encryption_type != "file"
-    ) ? true : trimspace(var.graphdb_data_encryption_master_key_secret) != ""
-    error_message = "Must set master key secret when using file-based data encryption"
+    ) ? true : trimspace(var.graphdb_data_encryption_master_key_filepath) != "" && fileexists(var.graphdb_data_encryption_master_key_filepath)
+    error_message = "Master key variable empty or file was not found"
   }
 }
 
 variable "graphdb_data_encryption_keystore_alias" {
   description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
   type        = string
+}
+
+variable "graphdb_data_encryption_keystore_filepath" {
+  description = "Local path to a keystore file containing the master key for encryption at rest setup"
+  type        = string
+  default     = ""
+  validation {
+    condition = (
+      var.graphdb_data_encryption_type != "file"
+    ) ? true : trimspace(var.graphdb_data_encryption_keystore_filepath) != "" && fileexists(var.graphdb_data_encryption_keystore_filepath)
+    error_message = "PKCS12 Keystore variable empty or file was not found"
+  }
 }
 
 variable "graphdb_data_encryption_keystore_password" {

--- a/variables.tf
+++ b/variables.tf
@@ -1301,9 +1301,8 @@ variable "graphdb_data_encryption_master_key_secret" {
   default = ""
   validation {
     condition = (
-      var.graphdb_data_encryption_type == "file" &&
-      trimspace(var.graphdb_data_encryption_master_key_secret) != ""
-      )
+      var.graphdb_data_encryption_type != "file"
+      ) ? true : trimspace(var.graphdb_data_encryption_master_key_secret) != ""
     error_message = "Must set master key secret when using file-based data encryption"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1286,42 +1286,41 @@ variable "m2m_scope" {
 
 variable "graphdb_data_encryption_type" {
   description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   validation {
-    condition = contains(["", "file", "pkcs12"], var.graphdb_data_encryption_type)
+    condition     = contains(["", "file", "pkcs12"], var.graphdb_data_encryption_type)
     error_message = "graphdb_data_encryption_type can be either empty, 'file' or 'pkcs12'"
   }
 }
 
 variable "graphdb_data_encryption_master_key_secret" {
   description = "The master key secret, when using file-based data encryption."
-  type = string
-  sensitive = true
-  default = ""
+  type        = string
+  sensitive   = true
+  default     = ""
   validation {
     condition = (
       var.graphdb_data_encryption_type != "file"
-      ) ? true : trimspace(var.graphdb_data_encryption_master_key_secret) != ""
+    ) ? true : trimspace(var.graphdb_data_encryption_master_key_secret) != ""
     error_message = "Must set master key secret when using file-based data encryption"
   }
 }
 
 variable "graphdb_data_encryption_keystore_alias" {
   description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
-  type = string
-  default = "masterkey"
+  type        = string
 }
 
 variable "graphdb_data_encryption_keystore_password" {
   description = "The keystore password for the data encryption keystore (when using type pkcs12)"
-  type = string
-  sensitive = true
-  default = ""
+  type        = string
+  sensitive   = true
+  default     = ""
   validation {
-      condition = (
-        var.graphdb_data_encryption_type != "pkcs12"
-      ) ? true : trimspace(var.graphdb_data_encryption_keystore_password) != ""
-      error_message = "PKCS12 Keystore password cannot be null when configuring PKCS12-based data encryption"
+    condition = (
+      var.graphdb_data_encryption_type != "pkcs12"
+    ) ? true : trimspace(var.graphdb_data_encryption_keystore_password) != ""
+    error_message = "PKCS12 Keystore password cannot be null when configuring PKCS12-based data encryption"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -396,7 +396,7 @@ variable "ami_id" {
 variable "graphdb_version" {
   description = "GraphDB version"
   type        = string
-  default     = "11.3.3"
+  default     = "11.4.0"
   nullable    = false
 }
 
@@ -1282,4 +1282,35 @@ variable "m2m_scope" {
   description = "The scope for the M2M application"
   type        = string
   default     = null
+}
+
+variable "graphdb_data_encryption_type" {
+  description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
+  type = string
+  default = ""
+  validation {
+    condition =
+      contains(["", "file", "pkcs12"], trimspace(var.graphdb_data_encryption_type)
+      error_message "graphdb_data_encryption_type can be either empty, 'file' or 'pkcs12'"
+  }
+}
+
+variable "graphdb_data_encryption_keystore_alias" {
+  description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
+  type = string
+  default = "masterkey"
+}
+
+variable "graphdb_data_encryption_keystore_password" {
+  description = "The keystore password for the data encryption keystore (when using type pkcs12)"
+  type = string
+  sensitive = true
+  default = null
+  validation {
+      condition = (
+        var.graphdb_data_encryption_type == "pkcs12" &&
+        trimspace(var.graphdb_data_encryption_keystore_password) != ""
+        )
+      error_message = "PKCS12 Keystore password cannot be null when configuring PKCS12-based data encryption"
+    }
 }


### PR DESCRIPTION
Update GDB to 13.4.0. Add Data Encryption at Rest

## Description

Sets GDB default version value to 13.4.0. 
Adds data encryption at rest configuration in 04_gdb_conf_overrides.sh.tpl via custom Java snippet
Adds variables

## Related Issues


## Changes

Adds a custom Java snippet inside 04_gdb_conf_overrides.sh.tpl to generate a Java keystore based on provided user password, in order to generate an identical AES symmetric key across all GDB cluster nodes

## Screenshots (if applicable)


## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
