### PR TITLE
[GDB-14666] Fixed encryption setting in the backup module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB AWS Terraform Module Changelog
 
+## 3.3.0
+
+* Fixed perpetual Terraform drift in `aws_s3_bucket_server_side_encryption_configuration` for the backup module by explicitly setting `blocked_encryption_types = ["SSE-C"]` to match the value AWS returns
+
 ## 3.2.2
 
 * Updated GraphDB default version to [11.3.3](https://graphdb.ontotext.com/documentation/11.3/release-notes.html#graphdb-11-3-3)

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -20,7 +20,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "backup" {
   bucket = aws_s3_bucket.graphdb_backup.id
 
   rule {
-    bucket_key_enabled = true
+    bucket_key_enabled       = true
+    blocked_encryption_types = ["SSE-C"]
 
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"


### PR DESCRIPTION
## Description

* We are seeing persistent drift when running terraform plan for environments utilizing our Terraform AWS GraphDB module. Terraform constantly attempts to remove "SSE-C" from the blocked_encryption_types array for the S3 buckets provisioned by this module, resulting in an ~ update in-place action that never actually resolves.  Starting on April 6, 2026, AWS changed the default behavior for S3. Amazon S3 now automatically disables Server-Side Encryption with Customer-provided keys (SSE-C) for all new general-purpose buckets and existing buckets that don't use it. Because the AWS API now returns ["SSE-C"] by default, but our GraphDB module does not specify this argument for its buckets, Terraform detects a mismatch and tries to revert it.

## Related Issues

[GDB-14666]

## Changes

* Fixed encryption setting in the backup module

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-14666]: https://graphwise.atlassian.net/browse/GDB-14666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ