### PR TITLE
[GDB-11490] Added audit logs for GraphDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # GraphDB AWS Terraform Module Changelog
 
 ## 3.3.0
-
+* Added `graphdb_enable_audit_log_enabled` variable to enable GraphDB audit logging
 * Fixed perpetual Terraform drift in `aws_s3_bucket_server_side_encryption_configuration` for the backup module by explicitly setting `blocked_encryption_types = ["SSE-C"]` to match the value AWS returns
 
 ## 3.2.2

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14` | no |
 | bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null` | no |
 | graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false` | no |
+| graphdb\_enable\_audit\_log | Enable or disable the GraphDB audit log | `bool` | `false` | no |
+| graphdb\_audit\_log\_role | Minimum role whose actions are audit-logged. Hierarchy: ANY > USER > REPO\_MANAGER > ADMIN | `string` | `"REPO_MANAGER"` | no |
+| graphdb\_audit\_log\_repository | Repository operation level to audit-log. Accepted values: READ, WRITE (READ includes WRITE) | `string` | `"WRITE"` | no |
+| graphdb\_audit\_log\_headers | Comma-separated list of HTTP request headers to include in the audit log. Empty string disables header logging. | `string` | `""` | no |
+| graphdb\_audit\_log\_request\_max\_length | Maximum length in bytes of the request body captured in the audit log. Null uses the GraphDB default. | `number` | `null` | no |
 | graphdb\_user\_supplied\_scripts\_pre\_userdata | A list of paths to user-supplied shell scripts (local files) to be injected as additional parts in the EC2 user\_data before the provisioning scripts. | `list(string)` | `[]` | no |
 | graphdb\_user\_supplied\_rendered\_templates\_pre\_userdata | A list of strings containing pre-rendered shell script content to be added as parts in EC2 user\_data before the provisioning scripts. | `list(string)` | `[]` | no |
 | graphdb\_user\_supplied\_templates\_pre\_userdata | A list of maps where each map contains a 'path' to the template file and a 'variables' map used to render it, injected before the provisioning scripts. | ```list(object({ path = string variables = map(any) }))``` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 | lb\_access\_logs\_expiration\_days | Define the days after which the LB access logs should be deleted. | `number` | `14` | no |
 | bucket\_replication\_destination\_region | Define in which Region should the bucket be replicated | `string` | `null` | no |
 | graphdb\_enable\_userdata\_scripts\_on\_reboot | (Experimental) Modifies cloud-config to always run user data scripts on EC2 boot | `bool` | `false` | no |
-| graphdb\_enable\_audit\_log | Enable or disable the GraphDB audit log | `bool` | `false` | no |
+| graphdb\_audit\_log\_enabled | Enable or disable the GraphDB audit log | `bool` | `false` | no |
 | graphdb\_audit\_log\_role | Minimum role whose actions are audit-logged. Hierarchy: ANY > USER > REPO\_MANAGER > ADMIN | `string` | `"REPO_MANAGER"` | no |
 | graphdb\_audit\_log\_repository | Repository operation level to audit-log. Accepted values: READ, WRITE (READ includes WRITE) | `string` | `"WRITE"` | no |
 | graphdb\_audit\_log\_headers | Comma-separated list of HTTP request headers to include in the audit log. Empty string disables header logging. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -317,6 +317,11 @@ module "graphdb" {
   # ASG Instance deployment options
 
   graphdb_enable_userdata_scripts_on_reboot      = var.graphdb_enable_userdata_scripts_on_reboot
+  graphdb_audit_log_enabled                      = var.graphdb_audit_log_enabled
+  graphdb_audit_log_role                         = var.graphdb_audit_log_role
+  graphdb_audit_log_repository                   = var.graphdb_audit_log_repository
+  graphdb_audit_log_headers                      = var.graphdb_audit_log_headers
+  graphdb_audit_log_request_max_length           = var.graphdb_audit_log_request_max_length
   user_supplied_scripts_pre_userdata             = var.graphdb_user_supplied_scripts_pre_userdata
   user_supplied_rendered_templates_pre_userdata  = var.graphdb_user_supplied_rendered_templates_pre_userdata
   user_supplied_templates_pre_userdata           = var.graphdb_user_supplied_templates_pre_userdata

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -102,6 +102,22 @@ cat << EOF > /etc/systemd/system/graphdb.service.d/overrides.conf
 Environment="GDB_HEAP_SIZE=$${JVM_MAX_MEMORY}g"
 EOF
 
+%{ if graphdb_enable_audit_log ~}
+log_with_timestamp "Configuring GraphDB audit log"
+cat << EOF >> /etc/graphdb/graphdb.properties
+graphdb.audit.log.enabled=true
+graphdb.audit.role=${graphdb_audit_log_role}
+graphdb.audit.repository=${graphdb_audit_log_repository}
+%{ if graphdb_audit_log_headers != "" ~}
+graphdb.audit.headers=${graphdb_audit_log_headers}
+%{ endif ~}
+%{ if graphdb_audit_log_request_max_length != null ~}
+graphdb.audit.request.max.length=${graphdb_audit_log_request_max_length}
+%{ endif ~}
+EOF
+log_with_timestamp "GraphDB audit log configuration completed"
+%{ endif ~}
+
 # Appends configuration overrides to graphdb.properties
 GDB_PROPERTIES=$(aws --cli-connect-timeout 300 ssm get-parameter --region ${region} --name "/${name}/graphdb/graphdb_properties" --with-decryption 2>/dev/null | jq -r .Parameter.Value | base64 -d || /bin/true)
 [[ -n $GDB_PROPERTIES ]] && echo "$GDB_PROPERTIES" >> /etc/graphdb/graphdb.properties

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -119,6 +119,11 @@ data "cloudinit_config" "graphdb_user_data" {
       openid_auth_database : var.openid_auth_database != null ? var.openid_auth_database : ""
       oauth_roles_claim : var.oauth_roles_claim
       oauth_roles_prefix : var.oauth_roles_prefix
+      graphdb_audit_log_enabled : var.graphdb_audit_log_enabled
+      graphdb_audit_log_role : var.graphdb_audit_log_role
+      graphdb_audit_log_repository : var.graphdb_audit_log_repository
+      graphdb_audit_log_headers : var.graphdb_audit_log_headers
+      graphdb_audit_log_request_max_length : var.graphdb_audit_log_request_max_length
     })
   }
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -233,6 +233,31 @@ variable "graphdb_enable_userdata_scripts_on_reboot" {
   type        = bool
 }
 
+variable "graphdb_audit_log_enabled" {
+  description = "Enable or disable the GraphDB audit log"
+  type        = bool
+}
+
+variable "graphdb_audit_log_role" {
+  description = "Minimum role whose actions are audit-logged. Hierarchy: ANY > USER > REPO_MANAGER > ADMIN"
+  type        = string
+}
+
+variable "graphdb_audit_log_repository" {
+  description = "Repository operation level to audit-log. Accepted values: READ, WRITE (READ includes WRITE)"
+  type        = string
+}
+
+variable "graphdb_audit_log_headers" {
+  description = "Comma-separated list of HTTP request headers to include in the audit log. Empty string disables header logging."
+  type        = string
+}
+
+variable "graphdb_audit_log_request_max_length" {
+  description = "Maximum length in bytes of the request body captured in the audit log. Null uses the GraphDB default."
+  type        = number
+}
+
 variable "lb_enable_private_access" {
   description = "Enable or disable the private access via PrivateLink to the GraphDB Cluster"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -709,6 +709,46 @@ variable "graphdb_enable_userdata_scripts_on_reboot" {
   default     = false
 }
 
+variable "graphdb_audit_log_enabled" {
+  description = "Enable or disable the GraphDB audit log"
+  type        = bool
+  default     = false
+}
+
+variable "graphdb_audit_log_role" {
+  description = "Minimum role whose actions are audit-logged. Hierarchy: ANY > USER > REPO_MANAGER > ADMIN"
+  type        = string
+  default     = "REPO_MANAGER"
+
+  validation {
+    condition     = contains(["ANY", "USER", "REPO_MANAGER", "ADMIN"], var.graphdb_audit_log_role)
+    error_message = "Possible values: ANY, USER, REPO_MANAGER, ADMIN."
+  }
+}
+
+variable "graphdb_audit_log_repository" {
+  description = "Repository operation level to audit-log. Accepted values: READ, WRITE (READ includes WRITE)"
+  type        = string
+  default     = "WRITE"
+
+  validation {
+    condition     = contains(["READ", "WRITE"], var.graphdb_audit_log_repository)
+    error_message = "Possible values: READ, WRITE."
+  }
+}
+
+variable "graphdb_audit_log_headers" {
+  description = "Comma-separated list of HTTP request headers to include in the audit log. Empty string disables header logging."
+  type        = string
+  default     = ""
+}
+
+variable "graphdb_audit_log_request_max_length" {
+  description = "Maximum length in bytes of the request body captured in the audit log. Null uses the GraphDB default."
+  type        = number
+  default     = null
+}
+
 variable "graphdb_user_supplied_scripts_pre_userdata" {
   description = "A list of paths to user-supplied shell scripts (local files) to be injected as additional parts in the EC2 user_data before the provisioning scripts."
   type        = list(string)


### PR DESCRIPTION
## Description

* Audit logs in GraphDB are now enabled out of the box.

## Related Issues

[GDB-11490]

## Changes

* Audit logs in GraphDB are now enabled out of the box.

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-11490]: https://graphwise.atlassian.net/browse/GDB-11490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ